### PR TITLE
Fix rig calibration

### DIFF
--- a/src/openMVG/rig/Rig.cpp
+++ b/src/openMVG/rig/Rig.cpp
@@ -294,26 +294,26 @@ bool Rig::optimizeCalibration()
   std::map<std::size_t, std::vector<double> > vMainPoses;
   for(std::size_t iView = 0 ; iView < _vLocalizationResults[0].size() ; ++iView )
   {
-    if(_vLocalizationResults[0][iView].isValid())
-    {
-      const geometry::Pose3 & pose = _vLocalizationResults[0][iView].getPose();
-      const openMVG::Mat3 & R = pose.rotation();
-      const openMVG::Vec3 & t = pose.translation();
+    if(!_vLocalizationResults[0][iView].isValid())
+      continue;
+    
+    const geometry::Pose3 & pose = _vLocalizationResults[0][iView].getPose();
+    const openMVG::Mat3 & R = pose.rotation();
+    const openMVG::Vec3 & t = pose.translation();
 
-      double angleAxis[3];
-      ceres::RotationMatrixToAngleAxis((const double*)R.data(), angleAxis);
+    double angleAxis[3];
+    ceres::RotationMatrixToAngleAxis((const double*)R.data(), angleAxis);
 
-      std::vector<double> mainPose;
-      mainPose.reserve(6); //angleAxis + translation
-      mainPose.push_back(angleAxis[0]);
-      mainPose.push_back(angleAxis[1]);
-      mainPose.push_back(angleAxis[2]);
-      mainPose.push_back(t(0));
-      mainPose.push_back(t(1));
-      mainPose.push_back(t(2));
+    std::vector<double> mainPose;
+    mainPose.reserve(6); //angleAxis + translation
+    mainPose.push_back(angleAxis[0]);
+    mainPose.push_back(angleAxis[1]);
+    mainPose.push_back(angleAxis[2]);
+    mainPose.push_back(t(0));
+    mainPose.push_back(t(1));
+    mainPose.push_back(t(2));
 
-      vMainPoses.emplace(iView, mainPose);
-    }
+    vMainPoses.emplace(iView, mainPose);
   }
   for(auto &elem : vMainPoses)
   {

--- a/src/openMVG/rig/Rig.cpp
+++ b/src/openMVG/rig/Rig.cpp
@@ -1,5 +1,7 @@
 #include "Rig.hpp"
 #include "rig_BA_ceres.hpp"
+
+#include <openMVG/logger.hpp>
 #include <openMVG/sfm/sfm_data_BA_ceres.hpp>
 
 #include <ceres/rotation.h>
@@ -57,6 +59,11 @@ void Rig::setTrackingResult(
 
 bool Rig::initializeCalibration()
 {
+  if(_isInitialized)
+  {
+    POPART_COUT("The rig is already initialized");
+    return _isInitialized;
+  }
   // check that there are cameras
   assert(_vLocalizationResults.size()>0);
   
@@ -125,7 +132,8 @@ bool Rig::initializeCalibration()
       }
     }
   }
-  return true;
+  _isInitialized = true;
+  return _isInitialized;
 }
 
 // From a set of relative pose, find the optimal one for a given tracker iTraker which
@@ -234,6 +242,12 @@ void Rig::displayRelativePoseReprojection(const geometry::Pose3 & relativePose, 
 
 bool Rig::optimizeCalibration()
 {
+  if(!_isInitialized)
+  {
+    POPART_COUT("The rig is yet initialized");
+    return _isInitialized;
+  }
+  
   assert(_vRelativePoses.size() > 0);
   assert(_vLocalizationResults.size() > 0);
   

--- a/src/openMVG/rig/Rig.cpp
+++ b/src/openMVG/rig/Rig.cpp
@@ -109,6 +109,12 @@ bool Rig::initializeCalibration()
                                                      resWitnessCamera[iView].getPose()));
       }
     }
+    if(vRelativePoses.empty())
+    {
+      POPART_CERR("Unable to find candidate poses between the main camera and "
+              "the witness camera " << iLocalizer << "\nAborting...");
+      return false;
+    }
     geometry::Pose3 optimalRelativePose;
     findBestRelativePose(vRelativePoses, iLocalizer, optimalRelativePose );
   

--- a/src/openMVG/rig/Rig.cpp
+++ b/src/openMVG/rig/Rig.cpp
@@ -86,7 +86,7 @@ bool Rig::initializeCalibration()
   _vRelativePoses.reserve(nCams-1);
   
   // Loop over all witness cameras
-  for (int iLocalizer=1 ; iLocalizer < nCams ; ++iLocalizer)
+  for(std::size_t iLocalizer=1 ; iLocalizer < nCams ; ++iLocalizer)
   {
     // Perform the pose averaging over all relative pose between the main camera
     // (index 0) and the witness camera (index i)
@@ -97,7 +97,7 @@ bool Rig::initializeCalibration()
     std::vector<geometry::Pose3> vRelativePoses;
     vRelativePoses.reserve(resWitnessCamera.size());
     
-    for(int iView=0 ; iView < resWitnessCamera.size() ; ++iView )
+    for(std::size_t iView=0 ; iView < resWitnessCamera.size() ; ++iView )
     {
       // Check that both pose computations succeeded 
       if ( resMainCamera[iView].isValid() && resWitnessCamera[iView].isValid() )
@@ -123,12 +123,12 @@ bool Rig::initializeCalibration()
   }
   
   // Update all poses in all localization results
-  for (int iRelativePose = 0 ; iRelativePose < _vRelativePoses.size() ; ++iRelativePose )
+  for(std::size_t iRelativePose = 0 ; iRelativePose < _vRelativePoses.size() ; ++iRelativePose )
   {
     std::size_t iRes = iRelativePose+1;
-    for (int iView = 0 ; iView < _vLocalizationResults[iRes].size() ; ++iView )
+    for(std::size_t iView = 0 ; iView < _vLocalizationResults[iRes].size() ; ++iView )
     {
-      if(  _vLocalizationResults[0][iView].isValid() )
+      if(_vLocalizationResults[0][iView].isValid())
       {
         const geometry::Pose3 & relativePose = _vRelativePoses[iRelativePose];
         
@@ -165,7 +165,7 @@ void Rig::findBestRelativePose(
     const geometry::Pose3 & relativePose = vPoses[i];
 
     double error = 0;
-    for(int j=0 ; j < resWitnessCamera.size() ; ++j )
+    for(std::size_t j=0 ; j < resWitnessCamera.size() ; ++j )
     {
       // Check that both pose computations succeeded 
       if ( ( resMainCamera[j].isValid() ) && ( resWitnessCamera[j].isValid() ) )
@@ -383,7 +383,7 @@ bool Rig::optimizeCalibration()
 
   // Set a LossFunction to be less penalized by false measurements
   //  - set it to NULL if you don't want use a lossFunction.
-  ceres::LossFunction * p_LossFunction = NULL;//new ceres::HuberLoss(Square(4.0));
+  ceres::LossFunction * p_LossFunction = nullptr;//new ceres::HuberLoss(Square(4.0));
   // todo: make the LOSS function and the parameter an option
 
   // For all visibility add reprojections errors:
@@ -478,18 +478,18 @@ bool Rig::optimizeCalibration()
   ceres::Solver::Summary summary;
   ceres::Solve(options, &problem, &summary);
   
-  if (openMVG_options._bCeres_Summary)
+  if(openMVG_options._bCeres_Summary)
     POPART_COUT(summary.FullReport());
 
   // If no error, get back refined parameters
-  if (!summary.IsSolutionUsable())
+  if(!summary.IsSolutionUsable())
   {
     if (openMVG_options._bVerbose)
       POPART_COUT("Bundle Adjustment failed.");
     return false;
   }
 
-  if (openMVG_options._bVerbose)
+  if(openMVG_options._bVerbose)
   {
     // Display statistics about the minimization
     POPART_COUT( "\n"
@@ -502,7 +502,7 @@ bool Rig::optimizeCalibration()
   }
 
   // Update relative pose after optimization
-  for (int iRelativePose = 0 ; iRelativePose < _vRelativePoses.size() ; ++iRelativePose )
+  for(std::size_t iRelativePose = 0 ; iRelativePose < _vRelativePoses.size() ; ++iRelativePose)
   {
     openMVG::Mat3 R_refined;
     std::vector<double> vPose;
@@ -515,9 +515,9 @@ bool Rig::optimizeCalibration()
   }
 
   // Update the main camera pose after optimization
-  for (int iView = 0 ; iView < _vLocalizationResults[0].size() ; ++iView )
+  for(std::size_t iView = 0 ; iView < _vLocalizationResults[0].size() ; ++iView)
   {
-    if( _vLocalizationResults[0][iView].isValid() )
+    if(_vLocalizationResults[0][iView].isValid())
     {
       openMVG::Mat3 R_refined;
       std::vector<double> vPose;
@@ -534,15 +534,15 @@ bool Rig::optimizeCalibration()
   displayRelativePoseReprojection(geometry::Pose3(openMVG::Mat3::Identity(), openMVG::Vec3::Zero()), 0);
 
   // Update all poses over all witness cameras after optimization
-  for (int iRelativePose = 0 ; iRelativePose < _vRelativePoses.size() ; ++iRelativePose )
+  for(std::size_t iRelativePose = 0; iRelativePose < _vRelativePoses.size(); ++iRelativePose)
   {
-    std::size_t iLocalizer = iRelativePose+1;
+    const std::size_t iLocalizer = iRelativePose+1;
     // Loop over all views
-    for (int iView = 0 ; iView < _vLocalizationResults[iLocalizer].size() ; ++iView )
+    for(std::size_t iView = 0; iView < _vLocalizationResults[iLocalizer].size(); ++iView)
     {
       // If the localization has succeeded then if the witness camera localization succeeded 
       // then update the pose else continue.
-      if( _vLocalizationResults[0][iView].isValid() && _vLocalizationResults[iLocalizer][iView].isValid() )
+      if(_vLocalizationResults[0][iView].isValid() && _vLocalizationResults[iLocalizer][iView].isValid())
       {
         // Retrieve the witness camera pose from the main camera one.
         const geometry::Pose3 poseWitnessCamera = poseFromMainToWitness(_vLocalizationResults[0][iView].getPose(), _vRelativePoses[iRelativePose]);
@@ -669,7 +669,7 @@ bool loadRigCalibration(const std::string &filename, std::vector<geometry::Pose3
     subposes.push_back(geometry::Pose3(rot, center));
   }
   
-  bool isOk = fs.good();
+  const bool isOk = fs.good();
   fs.close();
   return isOk;
 }
@@ -707,7 +707,7 @@ bool saveRigCalibration(const std::string &filename, const std::vector<geometry:
     fs << center(1) << std::endl;
     fs << center(2) << std::endl;
   }
-  bool isOk = fs.good();
+  const bool isOk = fs.good();
   fs.close();
   return isOk;
 }

--- a/src/openMVG/rig/Rig.cpp
+++ b/src/openMVG/rig/Rig.cpp
@@ -424,7 +424,7 @@ bool Rig::optimizeCalibration()
                                         &vMainPoses[iView][0]);
             }else
             {
-              std::cout << "Fail in adding residual block for the main camera" << std::endl;
+              POPART_CERR("Fail in adding residual block for the main camera");
             }
           }
 
@@ -450,7 +450,7 @@ bool Rig::optimizeCalibration()
                                         &vRelativePoses[iLocalizer-1][0]);
             }else
             {
-              std::cout << "Fail in adding residual block for a secondary camera" << std::endl;
+              POPART_CERR("Fail in adding residual block for a secondary camera");
             }
           }
         }
@@ -460,7 +460,7 @@ bool Rig::optimizeCalibration()
 
   // Configure a BA engine and run it
   // todo: Set the most appropriate options
-  openMVG::sfm::Bundle_Adjustment_Ceres::BA_options openMVG_options; // Set all
+  openMVG::sfm::Bundle_Adjustment_Ceres::BA_options openMVG_options(true); // Set all
   // the options field in our owm struct - unnecessary dependancy to openMVG here
   
   ceres::Solver::Options options;
@@ -478,13 +478,13 @@ bool Rig::optimizeCalibration()
   ceres::Solve(options, &problem, &summary);
   
   if (openMVG_options._bCeres_Summary)
-    std::cout << summary.FullReport() << std::endl;
+    POPART_COUT(summary.FullReport());
 
   // If no error, get back refined parameters
   if (!summary.IsSolutionUsable())
   {
     if (openMVG_options._bVerbose)
-      std::cout << "Bundle Adjustment failed." << std::endl;
+      POPART_COUT("Bundle Adjustment failed.");
     return false;
   }
   else // Solution is usable
@@ -492,14 +492,13 @@ bool Rig::optimizeCalibration()
     if (openMVG_options._bVerbose)
     {
       // Display statistics about the minimization
-      std::cout << std::endl
+      POPART_COUT( "\n"
         << "Bundle Adjustment statistics (approximated RMSE):\n"
         << " #localizers: " << _vLocalizationResults.size() << "\n"
         << " #views: " << _vLocalizationResults[0].size() << "\n"
         << " #residuals: " << summary.num_residuals << "\n"
         << " Initial RMSE: " << std::sqrt( summary.initial_cost / summary.num_residuals) << "\n"
-        << " Final RMSE: " << std::sqrt( summary.final_cost / summary.num_residuals) << "\n"
-        << std::endl;
+        << " Final RMSE: " << std::sqrt( summary.final_cost / summary.num_residuals) << "\n");
     }
     
     // Update relative pose after optimization
@@ -643,14 +642,14 @@ bool loadRigCalibration(const std::string &filename, std::vector<geometry::Pose3
   std::ifstream fs(filename, std::ios::in);
   if(!fs.is_open())
   {
-    std::cerr << "Unable to load the calibration file " << filename << std::endl;
+    POPART_CERR("Unable to load the calibration file " << filename);
     throw std::invalid_argument("Unable to load the calibration file "+filename);
   }  
   
   // first read the number of cameras subposes stores
   std::size_t numCameras = 0;
   fs >> numCameras;
-  std::cout << "Found " << numCameras << " cameras" << std::endl;
+  POPART_COUT("Found " << numCameras << " cameras");
   subposes.reserve(numCameras);
   
   for(std::size_t cam = 0; cam < numCameras; ++cam)
@@ -690,7 +689,7 @@ bool saveRigCalibration(const std::string &filename, const std::vector<geometry:
   std::ofstream fs(filename, std::ios::out);
   if(!fs.is_open())
   {
-    std::cerr << "Unable to create the calibration file " << filename << std::endl;
+    POPART_CERR("Unable to create the calibration file " << filename);
     throw std::invalid_argument("Unable to create the calibration file "+filename);
   }
   fs << subposes.size() << std::endl;

--- a/src/openMVG/rig/Rig.hpp
+++ b/src/openMVG/rig/Rig.hpp
@@ -19,12 +19,14 @@ namespace rig {
 class Rig {
 public:
   
-  Rig(){};
+  Rig() : _isInitialized(false) {};
  
   virtual ~Rig();
   
   // Accessors
   std::size_t nCams() const { return _vLocalizationResults.size(); }
+  
+  bool isInitialized() const { return _isInitialized; }
   
   std::vector<localization::LocalizationResult> & getLocalizationResults(IndexT i)
   { 
@@ -100,6 +102,8 @@ private:
   
   // Rig pose
   std::vector<geometry::Pose3> _vPoses; // (i.e., by convention, pose of the main camera)
+  
+  bool _isInitialized;
 };
 
 /*

--- a/src/software/RigCalibration/main_rigCalibration.cpp
+++ b/src/software/RigCalibration/main_rigCalibration.cpp
@@ -187,6 +187,7 @@ int main(int argc, char** argv)
       // parameters for voctree localizer
       POPART_COUT("\tvoctree: " << vocTreeFilepath);
       POPART_COUT("\tweights: " << weightsFilepath);
+      POPART_COUT("\toutfile: " << outputFile);
       POPART_COUT("\talgorithm: " << algostring);
       POPART_COUT("\tresults: " << numResults);
     }
@@ -257,7 +258,7 @@ int main(int argc, char** argv)
   rig::Rig rig;
 
   // Loop over all cameras of the rig
-  for(int idCamera = 0; idCamera < nCam; ++idCamera)
+  for(std::size_t idCamera = 0; idCamera < nCam; ++idCamera)
   {
     POPART_COUT("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
     POPART_COUT("CAMERA " << idCamera);
@@ -330,7 +331,7 @@ int main(int argc, char** argv)
 
     // print out some time stats
     POPART_COUT("\n\n******************************");
-    POPART_COUT("Localized " << frameCounter << " images");
+    POPART_COUT("Processed " << frameCounter << " images for camera " << idCamera);
     POPART_COUT("Processing took " << bacc::sum(stats) / 1000 << " [s] overall");
     POPART_COUT("Mean time for localization:   " << bacc::mean(stats) << " [ms]");
     POPART_COUT("Max time for localization:   " << bacc::max(stats) << " [ms]");
@@ -369,4 +370,6 @@ int main(int argc, char** argv)
     POPART_COUT("t\n" << pose.translation());
     POPART_COUT("--------------------\n");
   }
+  
+  return EXIT_SUCCESS;
 }

--- a/src/software/RigCalibration/main_rigCalibration.cpp
+++ b/src/software/RigCalibration/main_rigCalibration.cpp
@@ -347,7 +347,7 @@ int main(int argc, char** argv)
     {
       auto & currResult = rig.getLocalizationResults(idCam);
       std::size_t numLocalized = 0;
-      for( auto &curr : currResult)
+      for(const auto &curr : currResult)
       {
         if(curr.isValid())
           ++numLocalized;


### PR DESCRIPTION
connected to poparteu/openMVG#145

Fixes:
* ~~Add `OpenMVG_USE_POPART_LOG` in cmake to build with the logger~~  this is now in poparteu/openMVG#148 
* Fixes uncatched errors in main_rigCalibration
* Fixes a bug for `vMainPoses` which was accessed with improper indices
* Add some more asserts/checks