### PR TITLE
Re-enable logs and cmake variable to set it

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,11 @@ OPTION(OpenMVG_BUILD_VOCTREE "Build the vocabulary tree and localization module"
 OPTION(OpenMVG_USE_OPENMP "Enable OpenMP parallelization" ON)
 OPTION(OpenMVG_USE_CCTAG "Enable CCTAG markers" ON)
 OPTION(OpenMVG_USE_ALEMBIC "Enable Alembic I/O" OFF)
+OPTION(OpenMVG_USE_POPART_LOG "Enable POPART logger" ON)
+
+IF(OpenMVG_USE_POPART_LOG)
+  ADD_DEFINITIONS(-DWANTS_POPART_COUT)
+ENDIF()
 
 # ==============================================================================
 # Opencv is not used by openMVG but some samples show how to use openCV
@@ -563,6 +568,7 @@ MESSAGE("** Build OpenCV+OpenMVG samples programs: " ${OpenMVG_USE_OPENCV})
 MESSAGE("** Use OpenCV SIFT features: " ${OpenMVG_USE_OCVSIFT})
 MESSAGE("** Use CCTAG markers: " ${OpenMVG_USE_CCTAG})
 MESSAGE("** Build Alembic exporter: " ${OpenMVG_USE_ALEMBIC})
+MESSAGE("** Use POPART logger: " ${OpenMVG_USE_POPART_LOG})
 
 MESSAGE("\n")
 

--- a/src/openMVG/sfm/pipelines/localization/SfM_Localizer.cpp
+++ b/src/openMVG/sfm/pipelines/localization/SfM_Localizer.cpp
@@ -62,7 +62,7 @@ bool SfM_Localizer::Localize
       resection_data.pt3D);
     // Robust estimation of the Projection matrix and its precision
     const std::pair<double,double> ACRansacOut =
-      openMVG::robust::ACRANSAC(kernel, resection_data.vec_inliers, resection_data.max_iteration, &P, dPrecision);
+      openMVG::robust::ACRANSAC(kernel, resection_data.vec_inliers, resection_data.max_iteration, &P, dPrecision, true);
     // Update the upper bound precision of the model found by AC-RANSAC
     resection_data.error_max = ACRansacOut.first;
   }
@@ -91,7 +91,7 @@ bool SfM_Localizer::Localize
       KernelType kernel = KernelType(pt2Dundistorted, resection_data.pt3D, pinhole_cam->K());
       // Robust estimation of the Projection matrix and its precision
       const std::pair<double,double> ACRansacOut =
-        openMVG::robust::ACRANSAC(kernel, resection_data.vec_inliers, resection_data.max_iteration, &P, dPrecision);
+        openMVG::robust::ACRANSAC(kernel, resection_data.vec_inliers, resection_data.max_iteration, &P, dPrecision, true);
       // Update the upper bound precision of the model found by AC-RANSAC
       resection_data.error_max = ACRansacOut.first;
     }
@@ -101,7 +101,7 @@ bool SfM_Localizer::Localize
       KernelType kernel = KernelType(resection_data.pt2D, resection_data.pt3D, pinhole_cam->K());
       // Robust estimation of the Projection matrix and its precision
       const std::pair<double,double> ACRansacOut =
-        openMVG::robust::ACRANSAC(kernel, resection_data.vec_inliers, resection_data.max_iteration, &P, dPrecision);
+        openMVG::robust::ACRANSAC(kernel, resection_data.vec_inliers, resection_data.max_iteration, &P, dPrecision, true);
       // Update the upper bound precision of the model found by AC-RANSAC
       resection_data.error_max = ACRansacOut.first;
     }
@@ -113,7 +113,8 @@ bool SfM_Localizer::Localize
 #ifdef HAVE_CCTAG
   const bool bResection = (resection_data.vec_inliers.size() > MINIMUM_SAMPLES);
 #ifdef WANTS_POPART_COUT
-  if (!bResection) {
+  if (!bResection) 
+  {
     std::cout << "bResection is false";
     std::cout << " because resection_data.vec_inliers.size() = " << resection_data.vec_inliers.size();
     std::cout << " and MINIMUM_SAMPLES = " << MINIMUM_SAMPLES << std::endl;

--- a/src/openMVG/sfm/sfm_data_BA_ceres.hpp
+++ b/src/openMVG/sfm/sfm_data_BA_ceres.hpp
@@ -32,7 +32,7 @@ class Bundle_Adjustment_Ceres : public Bundle_Adjustment
     ceres::PreconditionerType _preconditioner_type;
     ceres::SparseLinearAlgebraLibraryType _sparse_linear_algebra_library_type;
 
-    BA_options(const bool bVerbose = false, bool bmultithreaded = true);
+    BA_options(const bool bVerbose = true, bool bmultithreaded = true);
   };
   private:
     BA_options _openMVG_options;

--- a/src/openMVG_Samples/robust_essential_spherical/robust_essential_spherical.cpp
+++ b/src/openMVG_Samples/robust_essential_spherical/robust_essential_spherical.cpp
@@ -162,7 +162,7 @@ int main() {
       Mat3 E;
       const double precision = std::numeric_limits<double>::infinity();
       const std::pair<double,double> ACRansacOut =
-        ACRANSAC(kernel, vec_inliers, 1024, &E, precision);
+        ACRANSAC(kernel, vec_inliers, 1024, &E, precision, true);
       const double & threshold = ACRansacOut.first;
       const double & NFA = ACRansacOut.second;
 


### PR DESCRIPTION
* Add `OpenMVG_USE_POPART_LOG` in cmake to build with the logger
* reverted changes of c9da3ed so that the logs are enabled by default