### PR TITLE
Infrastructure for on-demand disabling of CUDA in SIFT_CCTAG_describer.

### DIFF
--- a/src/openMVG/features/cctag/CCTAG_describer.cpp
+++ b/src/openMVG/features/cctag/CCTAG_describer.cpp
@@ -62,6 +62,11 @@ bool CCTAG_Image_describer::Set_configuration_preset(EDESCRIBER_PRESET preset)
   return _params->setPreset(preset);
 }
 
+void CCTAG_Image_describer::Set_use_cuda(bool use_cuda)
+{
+  _params->_useCuda = use_cuda;
+}
+
 bool CCTAG_Image_describer::Describe(const image::Image<unsigned char>& image,
     std::unique_ptr<Regions> &regions,
     const image::Image<unsigned char> * mask)

--- a/src/openMVG/features/cctag/CCTAG_describer.hpp
+++ b/src/openMVG/features/cctag/CCTAG_describer.hpp
@@ -22,6 +22,8 @@ public:
 
   bool Set_configuration_preset(EDESCRIBER_PRESET preset);
 
+  void Set_use_cuda(bool);
+
   /**
   @brief Detect regions on the image and compute their attributes (description)
   @param image Image.

--- a/src/openMVG/features/cctag/SIFT_CCTAG_describer.hpp
+++ b/src/openMVG/features/cctag/SIFT_CCTAG_describer.hpp
@@ -34,6 +34,11 @@ public:
 
   bool Set_configuration_preset(EDESCRIBER_PRESET preset);
 
+  void Set_cctag_use_cuda(bool use_cuda)
+  {
+    _cctagDescriber.Set_use_cuda(use_cuda);
+  }
+
   /**
   @brief Detect regions on the image and compute their attributes (description)
   @param image Image.

--- a/src/openMVG/localization/VoctreeLocalizer.cpp
+++ b/src/openMVG/localization/VoctreeLocalizer.cpp
@@ -392,6 +392,10 @@ bool VoctreeLocalizer::localizeFirstBestResult(const image::Image<unsigned char>
 #endif
   auto detect_start = std::chrono::steady_clock::now();
   _image_describer->Set_configuration_preset(param._featurePreset);
+#if HAVE_CCTAG
+  if (auto* p = dynamic_cast<features::SIFT_CCTAG_Image_describer*>(_image_describer))
+    p->Set_cctag_use_cuda(param._ccTagUseCuda);
+#endif
   _image_describer->Describe(imageGrey, tmpQueryRegions, nullptr);
   auto detect_end = std::chrono::steady_clock::now();
   auto detect_elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(detect_end - detect_start);
@@ -633,6 +637,10 @@ bool VoctreeLocalizer::localizeAllResults(const image::Image<unsigned char> & im
 #endif
   auto detect_start = std::chrono::steady_clock::now();
   _image_describer->Set_configuration_preset(param._featurePreset);
+#if HAVE_CCTAG
+  if (auto* p = dynamic_cast<features::SIFT_CCTAG_Image_describer*>(_image_describer))
+    p->Set_cctag_use_cuda(param._ccTagUseCuda);
+#endif
   _image_describer->Describe(imageGrey, tmpQueryRegions, nullptr);
   auto detect_end = std::chrono::steady_clock::now();
   auto detect_elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(detect_end - detect_start);

--- a/src/openMVG/localization/VoctreeLocalizer.hpp
+++ b/src/openMVG/localization/VoctreeLocalizer.hpp
@@ -51,13 +51,16 @@ public:
       _algorithm(Algorithm::FirstBest),
       _numResults(4),
       _maxResults(10),
-      _numCommonViews(3) { }
+      _numCommonViews(3),
+      _ccTagUseCuda(true)
+    { }
     
     bool _useGuidedMatching;    //< Enable/disable guided matching when matching images
     Algorithm _algorithm;       //< algorithm to use for localization
     size_t _numResults;         //< number of best matching images to retrieve from the database
     size_t _maxResults;         //< for algorithm AllResults, it stops the image matching when this number of matched images is reached
     size_t _numCommonViews;     //< number minimum common images in which a point must be seen to be used in cluster tracking
+    bool _ccTagUseCuda;         //< ccTag-CUDA cannot process frames at different resolutions ATM, so set to false if localizer is used on images of differing sizes
   };
   
 public:

--- a/src/software/RigCalibration/main_rigCalibration.cpp
+++ b/src/software/RigCalibration/main_rigCalibration.cpp
@@ -227,6 +227,7 @@ int main(int argc, char** argv)
     localization::VoctreeLocalizer::Parameters *casted = static_cast<localization::VoctreeLocalizer::Parameters *>(param);
     casted->_algorithm = localization::VoctreeLocalizer::initFromString(algostring);;
     casted->_numResults = numResults;
+    casted->_ccTagUseCuda = false;
   }
 #if HAVE_CCTAG
   else


### PR DESCRIPTION
This option enables us to use cctag without gpu. Default is on as before.

CUDA is turned off in rig calibration, as CUDA CCTAG does not yet
support changing resolutions (two cameras are at different resolutions).