### PR TITLE
[features][localization] update the namespace of svgVisualization

### DIFF
--- a/src/openMVG/features/svgVisualization.cpp
+++ b/src/openMVG/features/svgVisualization.cpp
@@ -15,7 +15,7 @@
 #include <algorithm> 
 
 namespace openMVG {
-namespace localization {
+namespace features {
 
 
 void saveMatches2SVG(const std::string &imagePathLeft,
@@ -121,7 +121,7 @@ void saveCCTag2SVG(const std::string &inputImagePath,
   svgStream.drawImage(inputImagePath, imageSize.first, imageSize.second);
     
   const auto &feat = cctags.Features();
-  const std::vector<CCTagDescriptor > &desc = cctags.Descriptors();
+  const std::vector<localization::CCTagDescriptor > &desc = cctags.Descriptors();
   
   for(std::size_t i = 0; i < desc.size(); ++i) 
   {
@@ -130,7 +130,7 @@ void saveCCTag2SVG(const std::string &inputImagePath,
     {
       continue;
     }
-    const CCTagKeypoint &kpt = feat[i];
+    const localization::CCTagKeypoint &kpt = feat[i];
     svgStream.drawCircle(kpt.x(), kpt.y(), 3.0f, svg::svgStyle().stroke("yellow", 2.0));
     svgStream.drawText(kpt.x(), kpt.y(), textSize, std::to_string(cctagId), "yellow");
   }
@@ -159,8 +159,8 @@ void saveCCTagMatches2SVG(const std::string &imagePathLeft,
 
   const auto &keypointsLeft = cctagLeft.Features();
   const auto &keypointsRight = cctagRight.Features();
-  const std::vector<CCTagDescriptor > &descLeft = cctagLeft.Descriptors();
-  const std::vector<CCTagDescriptor > &descRight = cctagRight.Descriptors();
+  const std::vector<localization::CCTagDescriptor > &descLeft = cctagLeft.Descriptors();
+  const std::vector<localization::CCTagDescriptor > &descRight = cctagRight.Descriptors();
   
   //just to be sure...
   assert(keypointsLeft.size() == descLeft.size());
@@ -253,6 +253,6 @@ void saveCCTagMatches2SVG(const std::string &imagePathLeft,
 }
 #endif
 
-} // namespace localization
+} // namespace features
 } // namespace openMVG
 

--- a/src/openMVG/features/svgVisualization.cpp
+++ b/src/openMVG/features/svgVisualization.cpp
@@ -12,8 +12,6 @@
 #endif
 #include "third_party/vectorGraphics/svgDrawer.hpp"
 
-#include <algorithm> 
-
 namespace openMVG {
 namespace features {
 

--- a/src/openMVG/features/svgVisualization.cpp
+++ b/src/openMVG/features/svgVisualization.cpp
@@ -1,13 +1,5 @@
-/* 
- * File:   svgVisualization.cpp
- * Author: sgaspari
- * 
- * Created on October 19, 2015, 9:46 AM
- */
-
 #include "svgVisualization.hpp"
 #if HAVE_CCTAG
-// #include <openMVG/localization/CCTagLocalizer.hpp>
 #include "cctag/CCTAG_describer.hpp"
 #endif
 #include "third_party/vectorGraphics/svgDrawer.hpp"

--- a/src/openMVG/features/svgVisualization.cpp
+++ b/src/openMVG/features/svgVisualization.cpp
@@ -7,7 +7,7 @@
 
 #include "svgVisualization.hpp"
 #if HAVE_CCTAG
-#include <openMVG/localization/CCTagLocalizer.hpp>
+// #include <openMVG/localization/CCTagLocalizer.hpp>
 #include "cctag/CCTAG_describer.hpp"
 #endif
 #include "third_party/vectorGraphics/svgDrawer.hpp"
@@ -119,7 +119,7 @@ void saveCCTag2SVG(const std::string &inputImagePath,
   svgStream.drawImage(inputImagePath, imageSize.first, imageSize.second);
     
   const auto &feat = cctags.Features();
-  const std::vector<localization::CCTagDescriptor > &desc = cctags.Descriptors();
+  const auto &desc = cctags.Descriptors();
   
   for(std::size_t i = 0; i < desc.size(); ++i) 
   {
@@ -128,7 +128,7 @@ void saveCCTag2SVG(const std::string &inputImagePath,
     {
       continue;
     }
-    const localization::CCTagKeypoint &kpt = feat[i];
+    const auto &kpt = feat[i];
     svgStream.drawCircle(kpt.x(), kpt.y(), 3.0f, svg::svgStyle().stroke("yellow", 2.0));
     svgStream.drawText(kpt.x(), kpt.y(), textSize, std::to_string(cctagId), "yellow");
   }
@@ -157,8 +157,8 @@ void saveCCTagMatches2SVG(const std::string &imagePathLeft,
 
   const auto &keypointsLeft = cctagLeft.Features();
   const auto &keypointsRight = cctagRight.Features();
-  const std::vector<localization::CCTagDescriptor > &descLeft = cctagLeft.Descriptors();
-  const std::vector<localization::CCTagDescriptor > &descRight = cctagRight.Descriptors();
+  const auto &descLeft = cctagLeft.Descriptors();
+  const auto &descRight = cctagRight.Descriptors();
   
   //just to be sure...
   assert(keypointsLeft.size() == descLeft.size());

--- a/src/openMVG/features/svgVisualization.hpp
+++ b/src/openMVG/features/svgVisualization.hpp
@@ -16,7 +16,7 @@
 #include <vector>
 
 namespace openMVG {
-namespace localization {
+namespace features {
 
 /**
  * @brief
@@ -118,6 +118,6 @@ void saveCCTagMatches2SVG(const std::string &imagePathLeft,
                      bool showNotMatched);
 #endif
 
-} // namespace localization
+} // namespace features
 } // namespace openMVG
 

--- a/src/openMVG/localization/CCTagLocalizer.cpp
+++ b/src/openMVG/localization/CCTagLocalizer.cpp
@@ -229,7 +229,7 @@ bool CCTagLocalizer::localize(const image::Image<unsigned char> & imageGrey,
     features::CCTAG_Regions &queryRegions = *dynamic_cast<features::CCTAG_Regions*> (tmpQueryRegions.get());
     
     // just debugging -- save the svg image with detected cctag
-    saveCCTag2SVG(imagePath, 
+    features::saveCCTag2SVG(imagePath, 
                   imageSize, 
                   queryRegions, 
                   param->_visualDebug+"/"+bfs::path(imagePath).stem().string()+".svg");
@@ -303,7 +303,7 @@ bool CCTagLocalizer::localize(const std::unique_ptr<features::Regions> &genQuery
       const std::string matchedPath = (bfs::path(_sfm_data.s_root_path) /  bfs::path(mview->s_Img_path)).string();
       
       
-      saveCCTagMatches2SVG(imagePath, 
+      features::saveCCTagMatches2SVG(imagePath, 
                            imageSize, 
                            queryRegions,
                            matchedPath,

--- a/src/openMVG/localization/VoctreeLocalizer.cpp
+++ b/src/openMVG/localization/VoctreeLocalizer.cpp
@@ -512,7 +512,7 @@ bool VoctreeLocalizer::localizeFirstBestResult(const image::Image<unsigned char>
       const std::string matchedImage = bfs::path(mview->s_Img_path).stem().string();
       const std::string matchedPath = (bfs::path(_sfm_data.s_root_path) /  bfs::path(mview->s_Img_path)).string();
       
-      saveMatches2SVG(imagePath,
+      features::saveMatches2SVG(imagePath,
                       queryImageSize,
                       queryRegions.GetRegionsPositions(),
                       matchedPath,
@@ -648,7 +648,7 @@ bool VoctreeLocalizer::localizeAllResults(const image::Image<unsigned char> & im
   if(!param._visualDebug.empty() && !imagePath.empty())
   {
     namespace bfs = boost::filesystem;
-    saveFeatures2SVG(imagePath, 
+    features::saveFeatures2SVG(imagePath, 
                      queryImageSize, 
                      tmpQueryRegions->GetRegionsPositions(),
                      param._visualDebug+"/"+bfs::path(imagePath).stem().string()+".svg");
@@ -753,7 +753,7 @@ bool VoctreeLocalizer::localizeAllResults(const image::Image<unsigned char> & im
       const std::string matchedPath = (bfs::path(_sfm_data.s_root_path) /  bfs::path(mview->s_Img_path)).string();
       
 
-      saveMatches2SVG(imagePath,
+      features::saveMatches2SVG(imagePath,
                       queryImageSize,
                       queryRegions.GetRegionsPositions(),
                       matchedPath,
@@ -825,7 +825,7 @@ bool VoctreeLocalizer::localizeAllResults(const image::Image<unsigned char> & im
   if(!param._visualDebug.empty() && !imagePath.empty())
   {
     namespace bfs = boost::filesystem;
-    saveFeatures2SVG(imagePath, 
+    features::saveFeatures2SVG(imagePath, 
                      queryImageSize, 
                      resectionData.pt2D,
                      param._visualDebug+"/"+bfs::path(imagePath).stem().string()+".associations.svg");

--- a/src/software/SfM/main_ComputeCCTagStructureFromKnownPoses.cpp
+++ b/src/software/SfM/main_ComputeCCTagStructureFromKnownPoses.cpp
@@ -173,7 +173,7 @@ int main(int argc, char **argv)
       if(!sDebugOutputDir.empty())
       {
         cameras::IntrinsicBase* intrinsics = reconstructionSfmData.GetIntrinsics().at(view->id_intrinsic).get();
-        localization::saveCCTag2SVG(view->s_Img_path, 
+        features::saveCCTag2SVG(view->s_Img_path, 
                 std::make_pair(intrinsics->w(), intrinsics->h()),
                 cctagRegions_debug,
                 (bfs::path(sDebugOutputDir) / bfs::path(bfs::path(view->s_Img_path).stem().string()+".svg")).string());
@@ -244,7 +244,7 @@ int main(int argc, char **argv)
 //
 //            View* view = reconstructionSfmData.GetViews().at(iObsViewId).get();
 //            cameras::IntrinsicBase* intrinsics = reconstructionSfmData.GetIntrinsics().at(view->id_intrinsic).get();
-//            localization::saveCCTag2SVG(view->s_Img_path, 
+//            features::saveCCTag2SVG(view->s_Img_path, 
 //                    std::make_pair(intrinsics->w(), intrinsics->h()),
 //                    cctagRegions_debug,
 //                    (cctagDir/(bfs::path(view->s_Img_path).stem().string()+".svg")).string());


### PR DESCRIPTION
Since 634c3eca9f079ee21920f87e720c3c7f75cb0110 svgVisualization has been moved from module `localization` to module `features` but its namespace was still `openMVG::localization`.