### PR TITLE
[localization] removed useless includes

### DIFF
--- a/src/software/Localization/voctreeQueryUtility.cpp
+++ b/src/software/Localization/voctreeQueryUtility.cpp
@@ -15,9 +15,6 @@
 
 #include <Eigen/Core>
 
-//#include "selection.hpp"
-#include <opencv2/opencv.hpp>
-
 #include <boost/program_options.hpp> 
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/tail.hpp>


### PR DESCRIPTION
Compilation fails when opencv are disabled.
OpenCV is not required for this binary

see https://github.com/poparteu/openMVG/pull/151#discussion_r67608065