### PR TITLE
Fix SIFT_CCTAG_describer serialization

### DIFF
--- a/src/openMVG/features/cctag/CCTAG_describer.cpp
+++ b/src/openMVG/features/cctag/CCTAG_describer.cpp
@@ -11,45 +11,52 @@
 namespace openMVG {
 namespace features {
 
-struct CCTAG_Image_describer::CCTagParameters : public cctag::Parameters 
+CCTAG_Image_describer::CCTagParameters::CCTagParameters(size_t nRings)
 {
-  CCTagParameters(size_t nRings) : cctag::Parameters(nRings) {}
-  
-  float _cannyThrLow;
-  float _cannyThrHigh;
-  
-  bool setPreset(EDESCRIBER_PRESET preset)
+  _internalParams = new cctag::Parameters(nRings);
+}
+
+CCTAG_Image_describer::CCTagParameters::~CCTagParameters()
+{
+  delete _internalParams;
+}
+
+bool CCTAG_Image_describer::CCTagParameters::setPreset(EDESCRIBER_PRESET preset)
+{
+  switch(preset)
   {
-    switch(preset)
-    {
-    // Normal lighting conditions: normal contrast
-    case LOW_PRESET:
-    case MEDIUM_PRESET:
-    case NORMAL_PRESET:
-      _cannyThrLow = 0.01f;
-      _cannyThrHigh = 0.04f;
-    break;
-    // Low lighting conditions: very low contrast
-    case HIGH_PRESET:
-    case ULTRA_PRESET:
-      _cannyThrLow = 0.002f;
-      _cannyThrHigh = 0.01f;
-    break;
-    }
-    return true;
+  // Normal lighting conditions: normal contrast
+  case LOW_PRESET:
+  case MEDIUM_PRESET:
+  case NORMAL_PRESET:
+    _cannyThrLow = 0.01f;
+    _cannyThrHigh = 0.04f;
+  break;
+  // Low lighting conditions: very low contrast
+  case HIGH_PRESET:
+  case ULTRA_PRESET:
+    _cannyThrLow = 0.002f;
+    _cannyThrHigh = 0.01f;
+  break;
   }
-};
+  return true;
+}
 
 
 CCTAG_Image_describer::CCTAG_Image_describer()
-    :Image_describer(), _params(new CCTagParameters(3)), _doAppend(false) {}
+  : Image_describer()
+  , _params(3)
+  , _doAppend(false)
+{}
     
 CCTAG_Image_describer::CCTAG_Image_describer(const std::size_t nRings, const bool doAppend)
-    :Image_describer(), _params(new CCTagParameters(nRings)), _doAppend(doAppend){}   
+  : Image_describer()
+  , _params(nRings)
+  , _doAppend(doAppend)
+  {}   
 
 CCTAG_Image_describer::~CCTAG_Image_describer() 
 {
-  delete _params;
 }
 
 void CCTAG_Image_describer::Allocate(std::unique_ptr<Regions> &regions) const
@@ -59,12 +66,12 @@ void CCTAG_Image_describer::Allocate(std::unique_ptr<Regions> &regions) const
 
 bool CCTAG_Image_describer::Set_configuration_preset(EDESCRIBER_PRESET preset)
 {
-  return _params->setPreset(preset);
+  return _params.setPreset(preset);
 }
 
 void CCTAG_Image_describer::Set_use_cuda(bool use_cuda)
 {
-  _params->_useCuda = use_cuda;
+  _params._internalParams->_useCuda = use_cuda;
 }
 
 bool CCTAG_Image_describer::Describe(const image::Image<unsigned char>& image,
@@ -92,12 +99,12 @@ bool CCTAG_Image_describer::Describe(const image::Image<unsigned char>& image,
     //// Invert the image
     //cv::Mat invertImg;
     //cv::bitwise_not(graySrc,invertImg);
-    cctag::cctagDetection(cctags,1,graySrc, *_params, durations );
+    cctag::cctagDetection(cctags,1,graySrc, *_params._internalParams, durations);
 #else //todo: #ifdef depreciated
     cctag::MemoryPool::instance().updateMemoryAuthorizedWithRAM();
     cctag::View cctagView((const unsigned char *) image.data(), image.Width(), image.Height(), image.Depth()*image.Width());
     boost::ptr_list<cctag::ICCTag> cctags;
-    cctag::cctagDetection(cctags, 1 ,cctagView._grayView ,*_params, durations );
+    cctag::cctagDetection(cctags, 1 ,cctagView._grayView ,*_params._internalParams, durations );
 #endif
     durations->print( std::cerr );
     

--- a/src/openMVG/features/cctag/CCTAG_describer.hpp
+++ b/src/openMVG/features/cctag/CCTAG_describer.hpp
@@ -8,11 +8,15 @@
 #include <iostream>
 #include <numeric>
 
+namespace cctag {
+  class Parameters; // Hidden implementation
+}
+
 namespace openMVG {
 namespace features {
 
-/** @brief CCTag filter pixel type */
 
+/** @brief CCTag filter pixel type */
 class CCTAG_Image_describer : public Image_describer
 {
 public:
@@ -41,15 +45,25 @@ public:
   template<class Archive>
   void serialize( Archive & ar )
   {
-    //ar(
-     //cereal::make_nvp("params", _params),
-     //cereal::make_nvp("bOrientation", _bOrientation));
+    ar(
+     cereal::make_nvp("cannyThrLow", _params._cannyThrLow),
+     cereal::make_nvp("cannyThrHigh", _params._cannyThrHigh));
   }
 
+  struct CCTagParameters
+  {
+    CCTagParameters(size_t nRings);
+    ~CCTagParameters();
+
+    bool setPreset(EDESCRIBER_PRESET preset);
+
+    float _cannyThrLow;
+    float _cannyThrHigh;
+    cctag::Parameters* _internalParams;
+  };
 private:
   //CCTag parameters
-  struct CCTagParameters; // Hidden implementation
-  CCTagParameters *_params;
+  CCTagParameters _params;
   bool _doAppend;
 };
 

--- a/src/openMVG/features/cctag/SIFT_CCTAG_describer.cpp
+++ b/src/openMVG/features/cctag/SIFT_CCTAG_describer.cpp
@@ -16,6 +16,10 @@ SIFT_CCTAG_Image_describer::SIFT_CCTAG_Image_describer(const SiftParams & params
 {
 }
 
+SIFT_CCTAG_Image_describer::~SIFT_CCTAG_Image_describer()
+{
+}
+
 bool SIFT_CCTAG_Image_describer::Set_configuration_preset(EDESCRIBER_PRESET preset)
 {
   bool res = _siftDescriber.Set_configuration_preset(preset);

--- a/src/openMVG/features/cctag/SIFT_CCTAG_describer.hpp
+++ b/src/openMVG/features/cctag/SIFT_CCTAG_describer.hpp
@@ -30,7 +30,7 @@ class SIFT_CCTAG_Image_describer : public Image_describer
 public:
   SIFT_CCTAG_Image_describer(const SiftParams & params = SiftParams(), bool bOrientation = true, std::size_t nRings = 3);
 
-  ~SIFT_CCTAG_Image_describer(){}
+  ~SIFT_CCTAG_Image_describer();
 
   bool Set_configuration_preset(EDESCRIBER_PRESET preset);
 
@@ -59,9 +59,8 @@ public:
   template<class Archive>
   void serialize( Archive & ar )
   {
-    //ar(
-    // cereal::make_nvp("params", _paramsSift),
-    // cereal::make_nvp("bOrientation", _bOrientation));
+    _siftDescriber.serialize<Archive>(ar);
+    _cctagDescriber.serialize<Archive>(ar);
   }
 
 private:


### PR DESCRIPTION
Serialization was producing an empty file for image describer and thus when using it in computeFeatures the parameters alwqys had the default value.
