### PR TITLE
Add Grasshopper and RED variants to camera db.

### DIFF
--- a/src/openMVG/exif/sensor_width_database/sensor_width_camera_database.txt
+++ b/src/openMVG/exif/sensor_width_database/sensor_width_camera_database.txt
@@ -2540,6 +2540,10 @@ Praktica;Praktica DCZ 2.2;5.33
 Praktica;Praktica DCZ 3.2;7.11
 Praktica;Praktica DCZ 3.3;7.11
 Praktica;Praktica DCZ 1.3;6.4
+PtGrey;PtGrey Grasshopper3 2048x1536;7.18
+PtGrey;PtGrey Grasshopper3 1920x1440;6.73
+Red;Red Mysterium-X 4K HD;20.74
+Red;Red Dragon 4K HD;19.19
 Ricoh;Ricoh GR;23.6
 Ricoh;Ricoh CX6;6.16
 Ricoh;Ricoh GR Digital 4;7.53


### PR DESCRIPTION
Nice to have when using WC/SDI for reconstruction.

Exif data can be added like this:
exiftool -Make='PtGrey' -Model='Grasshopper3 1920x1440' -FocalLength='3.5 mm' *.jpg