### PR TITLE
[sfm] BA: add options to refine intrinsics subparts and add boundaries

### DIFF
--- a/src/openMVG/cameras/Camera_Intrinsics.hpp
+++ b/src/openMVG/cameras/Camera_Intrinsics.hpp
@@ -23,6 +23,7 @@ namespace cameras {
 struct IntrinsicBase
 {
   unsigned int _w, _h;
+  double _initialFocalLengthPix = -1;
   std::string _serialNumber;
 
   IntrinsicBase(unsigned int w = 0, unsigned int h = 0, const std::string& serialNumber = ""):_w(w), _h(h), _serialNumber(serialNumber)
@@ -36,11 +37,17 @@ struct IntrinsicBase
   unsigned int w() const {return _w;}
   unsigned int h() const {return _h;}
   const std::string& serialNumber() const {return _serialNumber;}
+  double initialFocalLengthPix() const {return _initialFocalLengthPix;}
+  
   void setWidth(unsigned int w) { _w = w;}
   void setHeight(unsigned int h) { _h = h;}
   void setSerialNumber(const std::string& serialNumber)
   {
     _serialNumber = serialNumber;
+  }
+  void setInitialFocalLengthPix(double initialFocalLengthPix)
+  {
+    _initialFocalLengthPix = initialFocalLengthPix;
   }
 
   // Operator ==
@@ -133,6 +140,7 @@ struct IntrinsicBase
     ar(cereal::make_nvp("width", _w));
     ar(cereal::make_nvp("height", _h));
     ar(cereal::make_nvp("serialNumber", _serialNumber));
+    ar(cereal::make_nvp("initialFocalLengthPix", _initialFocalLengthPix));
   }
 
   /// Serialization in
@@ -141,15 +149,22 @@ struct IntrinsicBase
   {
     ar(cereal::make_nvp("width", _w));
     ar(cereal::make_nvp("height", _h));
+    // compatibility with older versions
     try
     {
-      // compatibility with older versions
       ar(cereal::make_nvp("serialNumber", _serialNumber));
     }
-    catch(cereal::Exception e)
+    catch(cereal::Exception& e)
     {
-      // if it fails, just use empty string
       _serialNumber = "";
+    }
+    try
+    {
+      ar(cereal::make_nvp("initialFocalLengthPix", _initialFocalLengthPix));
+    }
+    catch(cereal::Exception& e)
+    {
+      _initialFocalLengthPix = -1;
     }
   }
 

--- a/src/openMVG/localization/optimization.cpp
+++ b/src/openMVG/localization/optimization.cpp
@@ -251,7 +251,7 @@ bool refineSequence(std::vector<LocalizationResult> & vec_localizationResult,
   if(b_refine_pose)
     refineOptions |= sfm::BA_REFINE_ROTATION | sfm::BA_REFINE_TRANSLATION;
   if(b_refine_intrinsic)
-    refineOptions |= sfm::BA_REFINE_INTRINSICS;
+    refineOptions |= sfm::BA_REFINE_INTRINSICS_ALL;
   if(b_refine_structure)
     refineOptions |= sfm::BA_REFINE_STRUCTURE;
 

--- a/src/openMVG/sfm/pipelines/global/sfm_global_engine_relative_motions.cpp
+++ b/src/openMVG/sfm/pipelines/global/sfm_global_engine_relative_motions.cpp
@@ -451,7 +451,7 @@ bool GlobalSfMReconstructionEngine_RelativeMotions::Adjust()
   }
   BA_Refine refineOptions = BA_REFINE_ROTATION | BA_REFINE_TRANSLATION | BA_REFINE_STRUCTURE;
   if(!_bFixedIntrinsics)
-    refineOptions |= BA_REFINE_INTRINSICS;
+    refineOptions |= BA_REFINE_INTRINSICS_ALL;
   b_BA_Status = bundle_adjustment_obj.Adjust(_sfm_data, refineOptions);
   if (b_BA_Status && !_sLoggingFile.empty())
   {

--- a/src/openMVG/sfm/pipelines/localization/SfM_Localizer.cpp
+++ b/src/openMVG/sfm/pipelines/localization/SfM_Localizer.cpp
@@ -172,7 +172,7 @@ bool SfM_Localizer::RefinePose
   if(b_refine_pose)
     refineOptions |= BA_REFINE_ROTATION | BA_REFINE_TRANSLATION;
   if(b_refine_intrinsic)
-    refineOptions |= BA_REFINE_INTRINSICS;
+    refineOptions |= BA_REFINE_INTRINSICS_ALL;
 
   const bool b_BA_Status = bundle_adjustment_obj.Adjust(sfm_data, refineOptions);
   if (!b_BA_Status)

--- a/src/openMVG/sfm/pipelines/sequential/sequential_SfM.cpp
+++ b/src/openMVG/sfm/pipelines/sequential/sequential_SfM.cpp
@@ -1506,7 +1506,7 @@ bool SequentialSfMReconstructionEngine::BundleAdjustment()
   Bundle_Adjustment_Ceres bundle_adjustment_obj(options);
   BA_Refine refineOptions = BA_REFINE_ROTATION | BA_REFINE_TRANSLATION | BA_REFINE_STRUCTURE;
   if(!_bFixedIntrinsics)
-    refineOptions |= BA_REFINE_INTRINSICS;
+    refineOptions |= BA_REFINE_INTRINSICS_ALL;
   return bundle_adjustment_obj.Adjust(_sfm_data, refineOptions);
 }
 

--- a/src/openMVG/sfm/pipelines/sequential/sequential_SfM_test.cpp
+++ b/src/openMVG/sfm/pipelines/sequential/sequential_SfM_test.cpp
@@ -138,8 +138,8 @@ TEST(SEQUENTIAL_SFM, Partially_Known_Intrinsics) {
   const double dResidual = RMSE(sfmEngine.Get_SfM_Data());
   std::cout << "RMSE residual: " << dResidual << std::endl;
   EXPECT_TRUE( dResidual < 0.5);
-  EXPECT_TRUE( sfmEngine.Get_SfM_Data().GetPoses().size() == nviews);
-  EXPECT_TRUE( sfmEngine.Get_SfM_Data().GetLandmarks().size() == npoints);
+  EXPECT_EQ(nviews, sfmEngine.Get_SfM_Data().GetPoses().size());
+  EXPECT_EQ(npoints, sfmEngine.Get_SfM_Data().GetLandmarks().size());
 }
 
 /* ************************************************************************* */

--- a/src/openMVG/sfm/sfm_data_BA.hpp
+++ b/src/openMVG/sfm/sfm_data_BA.hpp
@@ -17,10 +17,15 @@ enum BA_Refine
   BA_REFINE_NONE = 0,
   BA_REFINE_ROTATION = 1, //< refine pose rotations
   BA_REFINE_TRANSLATION = 2, //< refine pose translations
-  BA_REFINE_INTRINSICS = 4, //< refine camera intrinsics
-  BA_REFINE_STRUCTURE = 8, //<  refine structure (i.e. 3D points)
+  BA_REFINE_STRUCTURE = 4, //<  refine structure (i.e. 3D points)
+  BA_REFINE_INTRINSICS_FOCAL = 8, //< refine the focal length
+  BA_REFINE_INTRINSICS_OPTICALCENTER_ALWAYS = 16, //< refine the optical center
+  BA_REFINE_INTRINSICS_OPTICALCENTER_IF_ENOUGH_DATA = 32, //< refine the optical center only if we have a minimum number of cameras
+  BA_REFINE_INTRINSICS_DISTORTION = 64, //< refine the distortion parameters
+  /// Refine all intrinsics parameters
+  BA_REFINE_INTRINSICS_ALL = BA_REFINE_INTRINSICS_FOCAL | BA_REFINE_INTRINSICS_OPTICALCENTER_IF_ENOUGH_DATA | BA_REFINE_INTRINSICS_DISTORTION,
   /// Refine all parameters
-  BA_REFINE_ALL = BA_REFINE_ROTATION | BA_REFINE_TRANSLATION | BA_REFINE_INTRINSICS | BA_REFINE_STRUCTURE,
+  BA_REFINE_ALL = BA_REFINE_ROTATION | BA_REFINE_TRANSLATION | BA_REFINE_INTRINSICS_ALL | BA_REFINE_STRUCTURE,
 };
 
 OPENMVG_BITMASK(BA_Refine)

--- a/src/openMVG/sfm/sfm_data_BA_ceres.cpp
+++ b/src/openMVG/sfm/sfm_data_BA_ceres.cpp
@@ -190,10 +190,9 @@ bool Bundle_Adjustment_Ceres::Adjust(
   const bool refineIntrinsics = (refineOptions & BA_REFINE_INTRINSICS_FOCAL) ||
                                 (refineOptions & BA_REFINE_INTRINSICS_DISTORTION) ||
                                 refineIntrinsicsOpticalCenter;
-  for (Views::const_iterator itView = sfm_data.views.begin();
-    itView != sfm_data.views.end(); ++itView)
+  for(const auto& itView: sfm_data.GetViews())
   {
-    View* v = itView->second.get();
+    const View* v = itView.second.get();
     if (sfm_data.IsPoseAndIntrinsicDefined(v))
     {
       if(intrinsicsUsage.find(v->id_intrinsic) == intrinsicsUsage.end())
@@ -210,16 +209,15 @@ bool Bundle_Adjustment_Ceres::Adjust(
 
   Hash_Map<IndexT, std::vector<double> > map_intrinsics;
   // Setup Intrinsics data & subparametrization
-  for (Intrinsics::const_iterator itIntrinsic = sfm_data.intrinsics.begin();
-    itIntrinsic != sfm_data.intrinsics.end(); ++itIntrinsic)
+  for(const auto& itIntrinsic: sfm_data.GetIntrinsics())
   {
-    const IndexT idIntrinsics = itIntrinsic->first;
+    const IndexT idIntrinsics = itIntrinsic.first;
     if(intrinsicsUsage[idIntrinsics] == 0)
     {
       continue;
     }
-    assert(isValid(itIntrinsic->second->getType()));
-    map_intrinsics[idIntrinsics] = itIntrinsic->second->getParams();
+    assert(isValid(itIntrinsic.second->getType()));
+    map_intrinsics[idIntrinsics] = itIntrinsic.second->getParams();
 
     double * parameter_block = &map_intrinsics[idIntrinsics][0];
     problem.AddParameterBlock(parameter_block, map_intrinsics[idIntrinsics].size());
@@ -236,13 +234,13 @@ bool Bundle_Adjustment_Ceres::Adjust(
       if(refineOptions & BA_REFINE_INTRINSICS_FOCAL)
       {
         // Refine the focal length
-        if(itIntrinsic->second->initialFocalLengthPix() > 0)
+        if(itIntrinsic.second->initialFocalLengthPix() > 0)
         {
           // If we have an initial guess, we only authorize a margin around this value.
           assert(map_intrinsics[idIntrinsics].size() >= 1);
-          const unsigned int maxFocalErr = 0.2 * std::max(itIntrinsic->second->w(), itIntrinsic->second->h());
-          problem.SetParameterLowerBound(parameter_block, 0, (double)itIntrinsic->second->initialFocalLengthPix() - maxFocalErr);
-          problem.SetParameterUpperBound(parameter_block, 0, (double)itIntrinsic->second->initialFocalLengthPix() + maxFocalErr);
+          const unsigned int maxFocalErr = 0.2 * std::max(itIntrinsic.second->w(), itIntrinsic.second->h());
+          problem.SetParameterLowerBound(parameter_block, 0, (double)itIntrinsic.second->initialFocalLengthPix() - maxFocalErr);
+          problem.SetParameterUpperBound(parameter_block, 0, (double)itIntrinsic.second->initialFocalLengthPix() + maxFocalErr);
         }
         else // no initial guess
         {
@@ -268,11 +266,11 @@ bool Bundle_Adjustment_Ceres::Adjust(
         assert(map_intrinsics[idIntrinsics].size() >= 3);
 
         // Add bounds to the principal point
-        problem.SetParameterLowerBound(parameter_block, 1, 0.45 * itIntrinsic->second->w());
-        problem.SetParameterUpperBound(parameter_block, 1, 0.55 * itIntrinsic->second->w());
+        problem.SetParameterLowerBound(parameter_block, 1, 0.45 * itIntrinsic.second->w());
+        problem.SetParameterUpperBound(parameter_block, 1, 0.55 * itIntrinsic.second->w());
 
-        problem.SetParameterLowerBound(parameter_block, 2, 0.45 * itIntrinsic->second->h());
-        problem.SetParameterUpperBound(parameter_block, 2, 0.55 * itIntrinsic->second->h());
+        problem.SetParameterLowerBound(parameter_block, 2, 0.45 * itIntrinsic.second->h());
+        problem.SetParameterUpperBound(parameter_block, 2, 0.55 * itIntrinsic.second->h());
       }
       else
       {

--- a/src/openMVG/sfm/sfm_data_BA_ceres.cpp
+++ b/src/openMVG/sfm/sfm_data_BA_ceres.cpp
@@ -186,7 +186,7 @@ bool Bundle_Adjustment_Ceres::Adjust(
   Hash_Map<IndexT, std::size_t> intrinsicsUsage;
 
   // Setup Intrinsics data & subparametrization
-  const bool refineIntrinsicsOpticalCenter = (refineOptions & BA_REFINE_INTRINSICS_OPTICALCENTER_ALWAYS) || (refineOptions & BA_REFINE_INTRINSICS_OPTICALCENTER_ALWAYS);
+  const bool refineIntrinsicsOpticalCenter = (refineOptions & BA_REFINE_INTRINSICS_OPTICALCENTER_ALWAYS) || (refineOptions & BA_REFINE_INTRINSICS_OPTICALCENTER_IF_ENOUGH_DATA);
   const bool refineIntrinsics = (refineOptions & BA_REFINE_INTRINSICS_FOCAL) ||
                                 (refineOptions & BA_REFINE_INTRINSICS_DISTORTION) ||
                                 refineIntrinsicsOpticalCenter;

--- a/src/openMVG/sfm/sfm_data_BA_ceres.cpp
+++ b/src/openMVG/sfm/sfm_data_BA_ceres.cpp
@@ -264,13 +264,16 @@ bool Bundle_Adjustment_Ceres::Adjust(
       {
         // Refine optical center within 10% of the image size.
         assert(map_intrinsics[idIntrinsics].size() >= 3);
-
+        
+        const double opticalCenterMinPercent = 0.45;
+        const double opticalCenterMaxPercent = 0.55;
+        
         // Add bounds to the principal point
-        problem.SetParameterLowerBound(parameter_block, 1, 0.45 * itIntrinsic.second->w());
-        problem.SetParameterUpperBound(parameter_block, 1, 0.55 * itIntrinsic.second->w());
+        problem.SetParameterLowerBound(parameter_block, 1, opticalCenterMinPercent * itIntrinsic.second->w());
+        problem.SetParameterUpperBound(parameter_block, 1, opticalCenterMaxPercent * itIntrinsic.second->w());
 
-        problem.SetParameterLowerBound(parameter_block, 2, 0.45 * itIntrinsic.second->h());
-        problem.SetParameterUpperBound(parameter_block, 2, 0.55 * itIntrinsic.second->h());
+        problem.SetParameterLowerBound(parameter_block, 2, opticalCenterMinPercent * itIntrinsic.second->h());
+        problem.SetParameterUpperBound(parameter_block, 2, opticalCenterMaxPercent * itIntrinsic.second->h());
       }
       else
       {

--- a/src/openMVG/sfm/sfm_data_BA_ceres.cpp
+++ b/src/openMVG/sfm/sfm_data_BA_ceres.cpp
@@ -257,9 +257,11 @@ bool Bundle_Adjustment_Ceres::Adjust(
         vec_constant_params.push_back(0);
       }
 
+      const std::size_t minImagesForOpticalCenter = 3;
+
       // Optical center
       if((refineOptions & BA_REFINE_INTRINSICS_OPTICALCENTER_ALWAYS) ||
-         ((refineOptions & BA_REFINE_INTRINSICS_OPTICALCENTER_IF_ENOUGH_DATA) && intrinsicsUsage[idIntrinsics] > 3)
+         ((refineOptions & BA_REFINE_INTRINSICS_OPTICALCENTER_IF_ENOUGH_DATA) && intrinsicsUsage[idIntrinsics] > minImagesForOpticalCenter)
          )
       {
         // Refine optical center within 10% of the image size.

--- a/src/openMVG/sfm/sfm_data_filters.hpp
+++ b/src/openMVG/sfm/sfm_data_filters.hpp
@@ -72,8 +72,8 @@ static Pair_Set Pair_filter
   return kept_pairs;
 }
 
-// Remove tracks that have a small angle (tracks with tiny angle leads to instable 3D points)
-// Return the number of removed tracks
+/// Remove observations with too large reprojection error.
+/// Return the number of removed tracks.
 static IndexT RemoveOutliers_PixelResidualError
 (
   SfM_Data & sfm_data,

--- a/src/software/SfM/main_SfMInit_ImageListing.cpp
+++ b/src/software/SfM/main_SfMInit_ImageListing.cpp
@@ -298,7 +298,8 @@ int main(int argc, char **argv)
     ++iter_image, ++my_progress_bar )
   {
     // Read meta data to fill camera parameter (w,h,focal,ppx,ppy) fields.
-    double width = -1.0, height = -1.0, focalPix = -1.0;
+    double width = -1.0;
+    double height = -1.0;
     ppx = ppy = -1.0;
     
     const std::string imageFilename = *iter_image;
@@ -412,6 +413,7 @@ int main(int argc, char **argv)
     }
 
     // Focal
+    double focalPix = -1.0;
     float focalLength_mm = 0.0;
     std::string sCamName;
     std::string sCamModel;
@@ -477,6 +479,8 @@ int main(int argc, char **argv)
 
       // Create the desired camera type
       intrinsic = createPinholeIntrinsic(camera_model, width, height, focalPix, ppx, ppy);
+
+      intrinsic->setInitialFocalLengthPix(focalPix);
 
       // Initialize distortion parameters
       switch(camera_model)


### PR DESCRIPTION
* add boundaries on optical center
* add boundaries on focal length if an initial guess was provided
* add options to refine intrinsics subparts: BA_REFINE_INTRINSICS_FOCAL,
BA_REFINE_INTRINSICS_OPTICALCENTER_ALWAYS,
BA_REFINE_INTRINSICS_DISTORTION
* add an option to refine the optical center only if we have enough
constraints / enough input images with the same intrinsics:
BA_REFINE_INTRINSICS_OPTICALCENTER_IF_ENOUGH_DATA

connected to poparteu/openMVG#31