### PR TITLE
MVE export fix to enable UID support

### DIFF
--- a/src/software/SfM/main_openMVG2MVE2.cpp
+++ b/src/software/SfM/main_openMVG2MVE2.cpp
@@ -81,7 +81,10 @@ bool exportToMVE2Format(
 
     // Prepare to write bundle file
     // Get cameras and features from OpenMVG
-    const size_t cameraCount = std::distance(sfm_data.GetViews().begin(), sfm_data.GetViews().end());
+    size_t cameraCount = 0;
+    for(const auto& view: sfm_data.GetViews())
+        if(sfm_data.IsPoseAndIntrinsicDefined(view.second.get()))
+            ++cameraCount;
     // Tally global set of feature landmarks
     const Landmarks & landmarks = sfm_data.GetLandmarks();
     const size_t featureCount = std::distance(landmarks.begin(), landmarks.end());
@@ -98,115 +101,111 @@ bool exportToMVE2Format(
     Image<RGBColor> image, image_ud, thumbnail;
     std::string sOutViewIteratorDirectory;
     std::size_t view_index = 0;
+    std::map<std::size_t, IndexT> viewIdToviewIndex;
     for(Views::const_iterator iter = sfm_data.GetViews().begin();
-      iter != sfm_data.GetViews().end(); ++iter, ++my_progress_bar, ++view_index)
+      iter != sfm_data.GetViews().end(); ++iter, ++my_progress_bar)
     {
       const View * view = iter->second.get();
 
-      if (sfm_data.IsPoseAndIntrinsicDefined(view))
-      {
-        // Create current view subdirectory 'view_xxxx.mve'
-        std::ostringstream padding;
-        // Warning: We use view_index instead of view->id_view because MVE use indexes instead of IDs.
-        padding << std::setw(4) << std::setfill('0') << view_index;
-
-        sOutViewIteratorDirectory = stlplus::folder_append_separator(sOutViewsDirectory) + "view_" + padding.str() + ".mve";
-        if (!stlplus::folder_exists(sOutViewIteratorDirectory))
-        {
-          stlplus::folder_create(sOutViewIteratorDirectory);
-        }
-
-        // We have a valid view with a corresponding camera & pose
-        const std::string srcImage = stlplus::create_filespec(sfm_data.s_root_path, view->s_Img_path);
-        const std::string dstImage =
-          stlplus::create_filespec(stlplus::folder_append_separator(sOutViewIteratorDirectory), "undistorted","png");
-
-        Intrinsics::const_iterator iterIntrinsic = sfm_data.GetIntrinsics().find(view->id_intrinsic);
-        const IntrinsicBase * cam = iterIntrinsic->second.get();
-        if (cam->have_disto())
-        {
-          // Undistort and save the image
-          ReadImage(srcImage.c_str(), &image);
-          UndistortImage(image, cam, image_ud, BLACK);
-          WriteImage(dstImage.c_str(), image_ud);
-        }
-        else // (no distortion)
-        {
-          // If extensions match, copy the PNG image
-          if (stlplus::extension_part(srcImage) == "PNG" ||
-            stlplus::extension_part(srcImage) == "png")
-          {
-            stlplus::file_copy(srcImage, dstImage);
-          }
-          else
-          {
-            ReadImage( srcImage.c_str(), &image);
-            WriteImage( dstImage.c_str(), image);
-          }
-        }
-
-        // Prepare to write an MVE 'meta.ini' file for the current view
-        const Pose3 pose = sfm_data.GetPoseOrDie(view);
-        const Pinhole_Intrinsic * pinhole_cam = static_cast<const Pinhole_Intrinsic *>(cam);
-
-        const Mat3 rotation = pose.rotation();
-        const Vec3 translation = pose.translation();
-        // Pixel aspect: assuming square pixels
-        const float pixelAspect = 1.f;
-        // Focal length and principal point must be normalized (0..1)
-        const float flen = pinhole_cam->focal() / static_cast<double>(std::max(cam->w(), cam->h()));
-        const float ppX = std::abs(pinhole_cam->principal_point()(0)/cam->w());
-        const float ppY = std::abs(pinhole_cam->principal_point()(1)/cam->h());
-
-        // For each camera, write to bundle:  focal length, radial distortion[0-1], rotation matrix[0-8], translation vector[0-2]
-        std::ostringstream fileOut;
-        fileOut
-          << "# MVE view meta data is stored in INI-file syntax." << fileOut.widen('\n')
-          << "# This file is generated, formatting will get lost." << fileOut.widen('\n')
-          << fileOut.widen('\n')
-          << "[camera]" << fileOut.widen('\n')
-          << "focal_length = " << flen << fileOut.widen('\n')
-          << "pixel_aspect = " << pixelAspect << fileOut.widen('\n')
-          << "principal_point = " << ppX << " " << ppY << fileOut.widen('\n')
-          << "rotation = " << rotation(0, 0) << " " << rotation(0, 1) << " " << rotation(0, 2) << " "
-          << rotation(1, 0) << " " << rotation(1, 1) << " " << rotation(1, 2) << " "
-          << rotation(2, 0) << " " << rotation(2, 1) << " " << rotation(2, 2) << fileOut.widen('\n')
-          << "translation = " << translation[0] << " " << translation[1] << " "
-          << translation[2] << " " << fileOut.widen('\n')
-          << fileOut.widen('\n')
-          << "[view]" << fileOut.widen('\n')
-          << "id = " << view_index << fileOut.widen('\n')
-          << "name = " << stlplus::filename_part(srcImage.c_str()) << fileOut.widen('\n');
-
-        // To do:  trim any extra separator(s) from openMVG name we receive, e.g.:
-        // '/home/insight/openMVG_KevinCain/openMVG_Build/software/SfM/ImageDataset_SceauxCastle/images//100_7100.JPG'
-        std::ofstream file(
-          stlplus::create_filespec(stlplus::folder_append_separator(sOutViewIteratorDirectory),
-          "meta","ini").c_str());
-        file << fileOut.str();
-        file.close();
-
-        out
-          << flen << " " << "0" << " " << "0" << "\n"  // Write '0' distortion values for pre-corrected images
-          << rotation(0, 0) << " " << rotation(0, 1) << " " << rotation(0, 2) << "\n"
-          << rotation(1, 0) << " " << rotation(1, 1) << " " << rotation(1, 2) << "\n"
-          << rotation(2, 0) << " " << rotation(2, 1) << " " << rotation(2, 2) << "\n"
-          << translation[0] << " " << translation[1] << " " << translation[2] << "\n";
-      }
-      else
-      {
-        // export a camera without pose & intrinsic info (export {0})
-        // see: https://github.com/simonfuhrmann/mve/blob/952a80b0be48e820b8c72de1d3df06efc3953bd3/libs/mve/bundle_io.cc#L448
-        for (int i = 0; i < 5 * 3; ++i)
-          out << "0" << (i % 3 == 2 ? "\n" : " ");
+      if (!sfm_data.IsPoseAndIntrinsicDefined(view))
         continue;
+
+      viewIdToviewIndex[view->id_view] = view_index;
+      // Create current view subdirectory 'view_xxxx.mve'
+      std::ostringstream padding;
+      // Warning: We use view_index instead of view->id_view because MVE use indexes instead of IDs.
+      padding << std::setw(4) << std::setfill('0') << view_index;
+
+      sOutViewIteratorDirectory = stlplus::folder_append_separator(sOutViewsDirectory) + "view_" + padding.str() + ".mve";
+      if (!stlplus::folder_exists(sOutViewIteratorDirectory))
+      {
+        stlplus::folder_create(sOutViewIteratorDirectory);
       }
+
+      // We have a valid view with a corresponding camera & pose
+      const std::string srcImage = stlplus::create_filespec(sfm_data.s_root_path, view->s_Img_path);
+      const std::string dstImage =
+        stlplus::create_filespec(stlplus::folder_append_separator(sOutViewIteratorDirectory), "undistorted","png");
+
+      Intrinsics::const_iterator iterIntrinsic = sfm_data.GetIntrinsics().find(view->id_intrinsic);
+      const IntrinsicBase * cam = iterIntrinsic->second.get();
+      if (cam->have_disto())
+      {
+        // Undistort and save the image
+        ReadImage(srcImage.c_str(), &image);
+        UndistortImage(image, cam, image_ud, BLACK);
+        WriteImage(dstImage.c_str(), image_ud);
+      }
+      else // (no distortion)
+      {
+        // If extensions match, copy the PNG image
+        if (stlplus::extension_part(srcImage) == "PNG" ||
+          stlplus::extension_part(srcImage) == "png")
+        {
+          stlplus::file_copy(srcImage, dstImage);
+        }
+        else
+        {
+          ReadImage( srcImage.c_str(), &image);
+          WriteImage( dstImage.c_str(), image);
+        }
+      }
+
+      // Prepare to write an MVE 'meta.ini' file for the current view
+      const Pose3 pose = sfm_data.GetPoseOrDie(view);
+      const Pinhole_Intrinsic * pinhole_cam = static_cast<const Pinhole_Intrinsic *>(cam);
+
+      const Mat3 rotation = pose.rotation();
+      const Vec3 translation = pose.translation();
+      // Pixel aspect: assuming square pixels
+      const float pixelAspect = 1.f;
+      // Focal length and principal point must be normalized (0..1)
+      const float flen = pinhole_cam->focal() / static_cast<double>(std::max(cam->w(), cam->h()));
+      const float ppX = std::abs(pinhole_cam->principal_point()(0)/cam->w());
+      const float ppY = std::abs(pinhole_cam->principal_point()(1)/cam->h());
+
+      // For each camera, write to bundle:  focal length, radial distortion[0-1], rotation matrix[0-8], translation vector[0-2]
+      std::ostringstream fileOut;
+      fileOut
+        << "# MVE view meta data is stored in INI-file syntax." << fileOut.widen('\n')
+        << "# This file is generated, formatting will get lost." << fileOut.widen('\n')
+        << fileOut.widen('\n')
+        << "[camera]" << fileOut.widen('\n')
+        << "focal_length = " << flen << fileOut.widen('\n')
+        << "pixel_aspect = " << pixelAspect << fileOut.widen('\n')
+        << "principal_point = " << ppX << " " << ppY << fileOut.widen('\n')
+        << "rotation = " << rotation(0, 0) << " " << rotation(0, 1) << " " << rotation(0, 2) << " "
+        << rotation(1, 0) << " " << rotation(1, 1) << " " << rotation(1, 2) << " "
+        << rotation(2, 0) << " " << rotation(2, 1) << " " << rotation(2, 2) << fileOut.widen('\n')
+        << "translation = " << translation[0] << " " << translation[1] << " "
+        << translation[2] << " " << fileOut.widen('\n')
+        << fileOut.widen('\n')
+        << "[view]" << fileOut.widen('\n')
+        << "id = " << view_index << fileOut.widen('\n')
+        << "name = " << stlplus::filename_part(srcImage.c_str()) << fileOut.widen('\n');
+
+      // To do:  trim any extra separator(s) from openMVG name we receive, e.g.:
+      // '/home/insight/openMVG_KevinCain/openMVG_Build/software/SfM/ImageDataset_SceauxCastle/images//100_7100.JPG'
+      std::ofstream file(
+        stlplus::create_filespec(stlplus::folder_append_separator(sOutViewIteratorDirectory),
+        "meta","ini").c_str());
+      file << fileOut.str();
+      file.close();
+
+      out
+        << flen << " " << "0" << " " << "0" << "\n"  // Write '0' distortion values for pre-corrected images
+        << rotation(0, 0) << " " << rotation(0, 1) << " " << rotation(0, 2) << "\n"
+        << rotation(1, 0) << " " << rotation(1, 1) << " " << rotation(1, 2) << "\n"
+        << rotation(2, 0) << " " << rotation(2, 1) << " " << rotation(2, 2) << "\n"
+        << translation[0] << " " << translation[1] << " " << translation[2] << "\n";
 
       // Save a thumbnail image "thumbnail.png", 50x50 pixels
       thumbnail = create_thumbnail(image, 50, 50);
       const std::string dstThumbnailImage =
         stlplus::create_filespec(stlplus::folder_append_separator(sOutViewIteratorDirectory), "thumbnail","png");
       WriteImage(dstThumbnailImage.c_str(), thumbnail);
+      
+      ++view_index;
     }
 
     // For each feature, write to bundle:  position XYZ[0-3], color RGB[0-2], all ref.view_id & ref.feature_id
@@ -227,8 +226,9 @@ bool exportToMVE2Format(
       for (Observations::const_iterator itObs = obs.begin(); itObs != obs.end(); ++itObs)
       {
           const IndexT viewId = itObs->first;
+          const IndexT viewIndex = viewIdToviewIndex[viewId];
           const IndexT featId = itObs->second.id_feat;
-          out << " " << viewId << " " << featId << " 0";
+          out << " " << viewIndex << " " << featId << " 0";
       }
       out << "\n";
     }


### PR DESCRIPTION
- Fix remapping view ID to index for camera and for 3D points
visibility.
- Don't export unreconstructed views: as we are doing a remapping from
viewId to viewIndex, it doesnt make sense to keep unreconstructed views.

Note: MVE supports unreconstructed views but not random IDs (as we can
do in openMVG with UID). MVE checks that "view_id < views.size()":
https://github.com/simonfuhrmann/mve/blob/8464613b6608a4fc7faee467397aba59fd0214f4/apps/dmrecon/dmrecon.cc#L289