### PR TITLE
[WIP] Fix Alembic importer for animated cameras

### DIFF
--- a/src/openMVG/sfm/AlembicExporter.cpp
+++ b/src/openMVG/sfm/AlembicExporter.cpp
@@ -354,10 +354,18 @@ void AlembicExporter::addCameraKeyframe(const geometry::Pose3 &pose,
   mcamObj.getSchema().set(camSample);
 }
 
-void AlembicExporter::jumpKeyframe()
+void AlembicExporter::jumpKeyframe(const std::string &imagePath)
 {
-  mxform.getSchema().setFromPrevious();
-  mcamObj.getSchema().setFromPrevious();
+  if(mxform.getSchema().getNumSamples() == 0)
+  {
+    cameras::Pinhole_Intrinsic default_intrinsic;
+    this->addCameraKeyframe(geometry::Pose3(), &default_intrinsic, imagePath, 0, 0);
+  }
+  else
+  {
+    mxform.getSchema().setFromPrevious();
+    mcamObj.getSchema().setFromPrevious();
+  }
 }
 
 void AlembicExporter::add(const sfm::SfM_Data &sfmdata, sfm::ESfM_Data flags_part)

--- a/src/openMVG/sfm/AlembicExporter.hpp
+++ b/src/openMVG/sfm/AlembicExporter.hpp
@@ -73,7 +73,7 @@ public:
   /**
    * @brief Register keyframe on the previous values
    */
-  void jumpKeyframe();
+  void jumpKeyframe(const std::string &imagePath);
   
   /**
    * @brief Add SfM Data

--- a/src/openMVG/sfm/AlembicExporter.hpp
+++ b/src/openMVG/sfm/AlembicExporter.hpp
@@ -73,7 +73,7 @@ public:
   /**
    * @brief Register keyframe on the previous values
    */
-  void jumpKeyframe(const std::string &imagePath);
+  void jumpKeyframe(const std::string &imagePath = std::string());
   
   /**
    * @brief Add SfM Data

--- a/src/openMVG/sfm/AlembicImporter.cpp
+++ b/src/openMVG/sfm/AlembicImporter.cpp
@@ -20,13 +20,13 @@ namespace openMVG {
 namespace dataio {
 
 template<class AbcArrayProperty, typename T>
-void getAbcArrayProp(ICompoundProperty& userProps, const std::string& id, chrono_t sampleTime, T& outputArray)
+void getAbcArrayProp(ICompoundProperty& userProps, const std::string& id, index_t sampleFrame, T& outputArray)
 {
   typedef typename AbcArrayProperty::sample_ptr_type sample_ptr_type;
 
   AbcArrayProperty prop(userProps, id);
   sample_ptr_type sample;
-  prop.get(sample, ISampleSelector(sampleTime));
+  prop.get(sample, ISampleSelector(sampleFrame));
   outputArray.assign(sample->get(), sample->get()+sample->size());
 }
 
@@ -37,11 +37,11 @@ void getAbcArrayProp(ICompoundProperty& userProps, const std::string& id, chrono
  *         if it's an array.
  * @param userProps
  * @param id
- * @param sampleTime
+ * @param sampleFrame
  * @return value
  */
 template<class AbcProperty>
-typename AbcProperty::traits_type::value_type getAbcProp(ICompoundProperty& userProps, const Alembic::Abc::PropertyHeader& propHeader, const std::string& id, chrono_t sampleTime)
+typename AbcProperty::traits_type::value_type getAbcProp(ICompoundProperty& userProps, const Alembic::Abc::PropertyHeader& propHeader, const std::string& id, index_t sampleFrame)
 {
   typedef typename AbcProperty::traits_type traits_type;
   typedef typename traits_type::value_type value_type;
@@ -53,14 +53,14 @@ typename AbcProperty::traits_type::value_type getAbcProp(ICompoundProperty& user
   {
     Alembic::Abc::ITypedArrayProperty<traits_type> prop(userProps, id);
     array_sample_ptr_type sample;
-    prop.get(sample, ISampleSelector(sampleTime));
+    prop.get(sample, ISampleSelector(sampleFrame));
     return (*sample)[0];
   }
   else
   {
     value_type v;
     AbcProperty prop(userProps, id);
-    prop.get(v, ISampleSelector(sampleTime));
+    prop.get(v, ISampleSelector(sampleFrame));
     return v;
   }
 }
@@ -179,7 +179,7 @@ bool AlembicImporter::readPointCloud(IObject iObj, M44d mat, sfm::SfM_Data &sfmd
   return true;
 }
 
-bool AlembicImporter::readCamera(IObject iObj, M44d mat, sfm::SfM_Data &sfmdata, sfm::ESfM_Data flags_part, const chrono_t sampleTime)
+bool AlembicImporter::readCamera(IObject iObj, M44d mat, sfm::SfM_Data &sfmdata, sfm::ESfM_Data flags_part, const index_t sampleFrame)
 {
   using namespace openMVG::geometry;
   using namespace openMVG::cameras;
@@ -188,10 +188,10 @@ bool AlembicImporter::readCamera(IObject iObj, M44d mat, sfm::SfM_Data &sfmdata,
   ICamera camera(iObj, kWrapExisting);
   ICameraSchema cs = camera.getSchema();
   CameraSample camSample;
-  if(sampleTime == 0)
+  if(sampleFrame == 0)
     camSample = cs.getValue();
   else
-    camSample = cs.getValue(ISampleSelector(sampleTime));
+    camSample = cs.getValue(ISampleSelector(sampleFrame));
 
   // Check if we have an associated image plane
   ICompoundProperty userProps = getAbcUserProperties(cs);
@@ -206,54 +206,54 @@ bool AlembicImporter::readCamera(IObject iObj, M44d mat, sfm::SfM_Data &sfmdata,
   {
     if(const Alembic::Abc::PropertyHeader *propHeader = userProps.getPropertyHeader("mvg_imagePath"))
     {
-      imagePath = getAbcProp<Alembic::Abc::IStringProperty>(userProps, *propHeader, "mvg_imagePath", sampleTime);
+      imagePath = getAbcProp<Alembic::Abc::IStringProperty>(userProps, *propHeader, "mvg_imagePath", sampleFrame);
     }
     if(userProps.getPropertyHeader("mvg_sensorSizePix"))
     {
       try {
-        getAbcArrayProp<Alembic::Abc::IUInt32ArrayProperty>(userProps, "mvg_sensorSizePix", sampleTime, sensorSize_pix);
+        getAbcArrayProp<Alembic::Abc::IUInt32ArrayProperty>(userProps, "mvg_sensorSizePix", sampleFrame, sensorSize_pix);
       } catch(Alembic::Util::v7::Exception&)
       {
-        getAbcArrayProp<Alembic::Abc::IInt32ArrayProperty>(userProps, "mvg_sensorSizePix", sampleTime, sensorSize_pix);
+        getAbcArrayProp<Alembic::Abc::IInt32ArrayProperty>(userProps, "mvg_sensorSizePix", sampleFrame, sensorSize_pix);
       }
       assert(sensorSize_pix.size() == 2);
     }
     if(const Alembic::Abc::PropertyHeader *propHeader = userProps.getPropertyHeader("mvg_intrinsicType"))
     {
-      mvg_intrinsicType = getAbcProp<Alembic::Abc::IStringProperty>(userProps, *propHeader, "mvg_intrinsicType", sampleTime);
+      mvg_intrinsicType = getAbcProp<Alembic::Abc::IStringProperty>(userProps, *propHeader, "mvg_intrinsicType", sampleFrame);
     }
     if(userProps.getPropertyHeader("mvg_intrinsicParams"))
     {
       Alembic::Abc::IDoubleArrayProperty prop(userProps, "mvg_intrinsicParams");
       std::shared_ptr<DoubleArraySample> sample;
-      prop.get(sample, ISampleSelector(sampleTime));
+      prop.get(sample, ISampleSelector(sampleFrame));
       mvg_intrinsicParams.assign(sample->get(), sample->get()+sample->size());
     }
     if(const Alembic::Abc::PropertyHeader *propHeader = userProps.getPropertyHeader("mvg_viewId"))
     {
       try {
-        id_view = getAbcProp<Alembic::Abc::IUInt32Property>(userProps, *propHeader, "mvg_viewId", sampleTime);
+        id_view = getAbcProp<Alembic::Abc::IUInt32Property>(userProps, *propHeader, "mvg_viewId", sampleFrame);
       } catch(Alembic::Util::v7::Exception&)
       {
-        id_view = getAbcProp<Alembic::Abc::IInt32Property>(userProps, *propHeader, "mvg_viewId", sampleTime);
+        id_view = getAbcProp<Alembic::Abc::IInt32Property>(userProps, *propHeader, "mvg_viewId", sampleFrame);
       }
     }
     if(const Alembic::Abc::PropertyHeader *propHeader = userProps.getPropertyHeader("mvg_poseId"))
     {
       try {
-        id_pose = getAbcProp<Alembic::Abc::IUInt32Property>(userProps, *propHeader, "mvg_poseId", sampleTime);
+        id_pose = getAbcProp<Alembic::Abc::IUInt32Property>(userProps, *propHeader, "mvg_poseId", sampleFrame);
       } catch(Alembic::Util::v7::Exception&)
       {
-        id_pose = getAbcProp<Alembic::Abc::IInt32Property>(userProps, *propHeader, "mvg_poseId", sampleTime);
+        id_pose = getAbcProp<Alembic::Abc::IInt32Property>(userProps, *propHeader, "mvg_poseId", sampleFrame);
       }
     }
     if(const Alembic::Abc::PropertyHeader *propHeader = userProps.getPropertyHeader("mvg_intrinsicId"))
     {
       try {
-        id_intrinsic = getAbcProp<Alembic::Abc::IUInt32Property>(userProps, *propHeader, "mvg_intrinsicId", sampleTime);
+        id_intrinsic = getAbcProp<Alembic::Abc::IUInt32Property>(userProps, *propHeader, "mvg_intrinsicId", sampleFrame);
       } catch(Alembic::Util::v7::Exception&)
       {
-        id_intrinsic = getAbcProp<Alembic::Abc::IInt32Property>(userProps, *propHeader, "mvg_intrinsicId", sampleTime);
+        id_intrinsic = getAbcProp<Alembic::Abc::IInt32Property>(userProps, *propHeader, "mvg_intrinsicId", sampleFrame);
       }
     }
   }
@@ -328,12 +328,10 @@ void AlembicImporter::visitObject(IObject iObj, M44d mat, sfm::SfM_Data &sfmdata
     else
     {
       std::cout << xform.getSchema().getNumSamples() << " samples found in this animated xform." << std::endl;
-      const float timebase = 1.0 / 24.0;
-      const float timestep = 1.0 / 24.0;
-      for(int frame = 0; frame < xform.getSchema().getNumSamples(); ++frame)
+      for(index_t frame = 0; frame < xform.getSchema().getNumSamples(); ++frame)
       {
-        xform.getSchema().get(xs, ISampleSelector(frame * timestep + timebase));
-        readCamera(iObj.getChild(0), mat * xs.getMatrix(), sfmdata, flags_part, frame * timestep + timebase);
+        xform.getSchema().get(xs, ISampleSelector(frame));
+        readCamera(iObj.getChild(0), mat * xs.getMatrix(), sfmdata, flags_part, frame);
       }
     }
   }

--- a/src/openMVG/sfm/AlembicImporter.hpp
+++ b/src/openMVG/sfm/AlembicImporter.hpp
@@ -31,7 +31,7 @@ public:
 
 private:
   bool readPointCloud(IObject iObj, M44d mat, sfm::SfM_Data &sfmdata, sfm::ESfM_Data flags_part);
-  bool readCamera(IObject iObj, M44d mat, sfm::SfM_Data &sfmdata, sfm::ESfM_Data flags_part, const chrono_t sampleTime = 0.0);
+  bool readCamera(IObject iObj, M44d mat, sfm::SfM_Data &sfmdata, sfm::ESfM_Data flags_part, const index_t sampleFrame = 0);
   
   //@todo complete the interface, also maybe parameters need to be passed by reference?
   void visitObject(IObject iObj, M44d mat, sfm::SfM_Data &sfmdata, sfm::ESfM_Data flags_part = sfm::ESfM_Data::ALL);

--- a/src/openMVG/sfm/sfm_data_io_gt.cpp
+++ b/src/openMVG/sfm/sfm_data_io_gt.cpp
@@ -122,7 +122,7 @@ bool read_Strecha_Camera(const std::string & camName, cameras::Pinhole_Intrinsic
 @param[in] useUID, set to false to disable UID".
 @return Returns true if data has been read without errors
 **/
-bool readGt(const std::string sRootPath, SfM_Data & sfm_data, bool useUID)
+bool readGt(const std::string & sRootPath, SfM_Data & sfm_data, bool useUID)
 {
   // IF GT_Folder exists, perform evaluation of the quality of rotation estimates
   const std::string sGTPath = stlplus::folder_down(sRootPath, "gt_dense_cameras");
@@ -164,9 +164,9 @@ bool readGt(const std::string sRootPath, SfM_Data & sfm_data, bool useUID)
     std::cout << "No camera found in " << sGTPath << std::endl;
     return false;
   }
-  IndexT id = 0;
+  IndexT index = 0;
   for (std::vector<std::string>::const_iterator iter = vec_camfilenames.begin();
-    iter != vec_camfilenames.end(); ++iter, ++id)
+    iter != vec_camfilenames.end(); ++iter, ++index)
   {
     geometry::Pose3 pose;
     std::shared_ptr<cameras::Pinhole_Intrinsic> pinholeIntrinsic = std::make_shared<cameras::Pinhole_Intrinsic>();
@@ -180,7 +180,7 @@ bool readGt(const std::string sRootPath, SfM_Data & sfm_data, bool useUID)
     const std::string sImgName = stlplus::basename_part(*iter);
     const std::string sImgFile = stlplus::create_filespec(sImgPath, sImgName);
 
-    IndexT used_id = id;
+    IndexT used_id = index;
     if(useUID)
     {
       // Generate UID
@@ -194,9 +194,9 @@ bool readGt(const std::string sRootPath, SfM_Data & sfm_data, bool useUID)
     }
 
     // Update intrinsics with width and height of image
-    sfm_data.views.emplace(used_id, std::make_shared<View>(stlplus::basename_part(*iter), used_id, id, id, pinholeIntrinsic->w(), pinholeIntrinsic->h()));
-    sfm_data.poses.emplace(id, pose);
-    sfm_data.intrinsics.emplace(id, pinholeIntrinsic);
+    sfm_data.views.emplace(used_id, std::make_shared<View>(stlplus::basename_part(*iter), used_id, index, index, pinholeIntrinsic->w(), pinholeIntrinsic->h()));
+    sfm_data.poses.emplace(index, pose);
+    sfm_data.intrinsics.emplace(index, pinholeIntrinsic);
   }
   return true;
 }

--- a/src/openMVG/sfm/sfm_data_io_gt.cpp
+++ b/src/openMVG/sfm/sfm_data_io_gt.cpp
@@ -5,11 +5,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include "sfm_data_io_gt.hpp"
+#include "openMVG/sfm/sfm_data_io_gt.hpp"
 
-#include "openMVG/exif/exif_IO_EasyExif.hpp"
+#include <openMVG/exif/exif_IO_EasyExif.hpp>
 
-#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
+#include <third_party/stlplus3/filesystemSimplified/file_system.hpp>
 
 #include <fstream>
 #include <vector>

--- a/src/openMVG/sfm/sfm_data_io_gt.cpp
+++ b/src/openMVG/sfm/sfm_data_io_gt.cpp
@@ -1,0 +1,205 @@
+
+// Copyright (c) 2012, 2013, 2014 Pierre MOULON.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "sfm_data_io_gt.hpp"
+
+#include "openMVG/exif/exif_IO_EasyExif.hpp"
+
+#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace openMVG {
+namespace sfm {
+
+bool read_openMVG_Camera(const std::string & camName, cameras::Pinhole_Intrinsic & cam, geometry::Pose3 & pose)
+{
+  std::vector<double> val;
+  if (stlplus::extension_part(camName) == "bin")
+  {
+    std::ifstream in(camName.c_str(), std::ios::in|std::ios::binary);
+    if (!in.is_open())
+    {
+      std::cerr << "Error: failed to open file '" << camName << "' for reading" << std::endl;
+      return false;
+    }
+    val.resize(12);
+    in.read((char*)&val[0],(std::streamsize)12*sizeof(double));
+    if (in.fail())
+    {
+      val.clear();
+      return false;
+    }
+  }
+  else
+  {
+    std::ifstream ifs;
+    ifs.open( camName.c_str(), std::ifstream::in);
+    if (!ifs.is_open()) {
+      std::cerr << "Error: failed to open file '" << camName << "' for reading" << std::endl;
+      return false;
+    }
+    while (ifs.good())
+    {
+      double valT;
+      ifs >> valT;
+      if (!ifs.fail())
+        val.push_back(valT);
+    }
+  }
+
+  //Update the camera from file value
+  Mat34 P;
+  if (stlplus::extension_part(camName) == "bin")
+  {
+    P << val[0], val[3], val[6], val[9],
+      val[1], val[4], val[7], val[10],
+      val[2], val[5], val[8], val[11];
+  }
+  else
+  {
+    P << val[0], val[1], val[2], val[3],
+      val[4], val[5], val[6], val[7],
+      val[8], val[9], val[10], val[11];
+  }
+  Mat3 K, R;
+  Vec3 t;
+  KRt_From_P(P, &K, &R, &t);
+  cam = cameras::Pinhole_Intrinsic(0,0,K);
+  // K.transpose() is applied to give [R t] to the constructor instead of P = K [R t]
+  pose = geometry::Pose3(K.transpose() * P);
+  return true;
+}
+
+bool read_Strecha_Camera(const std::string & camName, cameras::Pinhole_Intrinsic & cam, geometry::Pose3 & pose)
+{
+  std::ifstream ifs;
+  ifs.open( camName.c_str(), std::ifstream::in);
+  if (!ifs.is_open()) {
+    std::cerr << "Error: failed to open file '" << camName << "' for reading" << std::endl;
+    return false;
+  }
+  std::vector<double> val;
+  while (ifs.good() && !ifs.eof())
+  {
+    double valT;
+    ifs >> valT;
+    if (!ifs.fail())
+      val.push_back(valT);
+  }
+
+  if (!(val.size() == 3*3 +3 +3*3 +3 + 3 || val.size() == 26)) //Strecha cam
+  {
+    std::cerr << "File " << camName << " is not in Stretcha format ! " << std::endl;
+    return false;
+  }
+  Mat3 K, R;
+  K << val[0], val[1], val[2],
+    val[3], val[4], val[5],
+    val[6], val[7], val[8];
+  R << val[12], val[13], val[14],
+    val[15], val[16], val[17],
+    val[18], val[19], val[20];
+
+  Vec3 C (val[21], val[22], val[23]);
+  // R need to be transposed
+  cam = cameras::Pinhole_Intrinsic(0,0,K);
+  cam.setWidth(val[24]);
+  cam.setHeight(val[25]);
+  pose = geometry::Pose3(R.transpose(), C);
+  return true;
+}
+
+/**
+@brief Reads a set of Pinhole Cameras and its poses from a ground truth dataset.
+@param[in] sRootPath, the directory containing an image folder "images" and a GT folder "gt_dense_cameras".
+@param[out] sfm_data, the SfM_Data structure to put views/poses/intrinsics in.
+@param[in] useUID, set to false to disable UID".
+@return Returns true if data has been read without errors
+**/
+bool readGt(const std::string sRootPath, SfM_Data & sfm_data, bool useUID)
+{
+  // IF GT_Folder exists, perform evaluation of the quality of rotation estimates
+  const std::string sGTPath = stlplus::folder_down(sRootPath, "gt_dense_cameras");
+  if (!stlplus::is_folder(sGTPath))
+  {
+    std::cout << std::endl << "There is not valid GT data to read from " << sGTPath << std::endl;
+    return false;
+  }
+
+  // Switch between case to choose the file reader according to the file types in GT path
+  bool (*fcnReadCamPtr)(const std::string &, cameras::Pinhole_Intrinsic &, geometry::Pose3&);
+  std::string suffix;
+  if (!stlplus::folder_wildcard(sGTPath, "*.bin", true, true).empty())
+  {
+    std::cout << "\nusing openMVG Camera";
+    fcnReadCamPtr = &read_openMVG_Camera;
+    suffix = "bin";
+  }
+  else if (!stlplus::folder_wildcard(sGTPath, "*.camera", true, true).empty())
+  {
+    std::cout << "\nusing Strechas Camera";
+    fcnReadCamPtr = &read_Strecha_Camera;
+    suffix = "camera";
+  }
+  else
+  {
+    throw std::logic_error(std::string("No camera found in ") + sGTPath);
+  }
+
+  std::cout << std::endl << "Read rotation and translation estimates" << std::endl;
+  const std::string sImgPath = stlplus::folder_down(sRootPath, "images");
+  std::map< std::string, Mat3 > map_R_gt;
+  //Try to read .suffix camera (parse camera names)
+  std::vector<std::string> vec_camfilenames =
+    stlplus::folder_wildcard(sGTPath, "*."+suffix, true, true);
+  std::sort(vec_camfilenames.begin(), vec_camfilenames.end());
+  if (vec_camfilenames.empty())
+  {
+    std::cout << "No camera found in " << sGTPath << std::endl;
+    return false;
+  }
+  IndexT id = 0;
+  for (std::vector<std::string>::const_iterator iter = vec_camfilenames.begin();
+    iter != vec_camfilenames.end(); ++iter, ++id)
+  {
+    geometry::Pose3 pose;
+    std::shared_ptr<cameras::Pinhole_Intrinsic> pinholeIntrinsic = std::make_shared<cameras::Pinhole_Intrinsic>();
+    bool loaded = fcnReadCamPtr(stlplus::create_filespec(sGTPath, *iter), *pinholeIntrinsic.get(), pose);
+    if (!loaded)
+    {
+      std::cout << "Failed to load: " << *iter << std::endl;
+      return false;
+    }
+
+    const std::string sImgName = stlplus::basename_part(*iter);
+    const std::string sImgFile = stlplus::create_filespec(sImgPath, sImgName);
+
+    IndexT used_id = id;
+    if(useUID)
+    {
+      // Generate UID
+      if (!stlplus::file_exists(sImgFile))
+      {
+        throw std::logic_error("Impossible to generate UID from this file, because it does not exists: "+sImgFile);
+      }
+      exif::Exif_IO_EasyExif exifReader;
+      exifReader.open( sImgFile );
+      used_id = (IndexT) computeUID(exifReader, sImgName);
+    }
+
+    // Update intrinsics with width and height of image
+    sfm_data.views.emplace(used_id, std::make_shared<View>(stlplus::basename_part(*iter), used_id, id, id, pinholeIntrinsic->w(), pinholeIntrinsic->h()));
+    sfm_data.poses.emplace(id, pose);
+    sfm_data.intrinsics.emplace(id, pinholeIntrinsic);
+  }
+  return true;
+}
+
+} // namespace sfm
+} // namespace openMVG

--- a/src/openMVG/sfm/sfm_data_io_gt.hpp
+++ b/src/openMVG/sfm/sfm_data_io_gt.hpp
@@ -6,8 +6,10 @@
 
 #pragma once
 
-#include "openMVG/geometry/pose3.hpp"
 #include "openMVG/sfm/sfm_data.hpp"
+
+#include <openMVG/geometry/pose3.hpp>
+#include <openMVG/cameras/Camera_Pinhole.hpp>
 
 #include <string>
 

--- a/src/openMVG/sfm/sfm_data_io_gt.hpp
+++ b/src/openMVG/sfm/sfm_data_io_gt.hpp
@@ -192,7 +192,7 @@ bool readGt(const std::string sRootPath, SfM_Data & sfm_data)
     const size_t uid = computeUID(exifReader, sImgName);
 
     // Update intrinsics with width and height of image
-    sfm_data.views.emplace((IndexT)uid, std::make_shared<View>(stlplus::basename_part(*iter), id, id, id, pinholeIntrinsic->w(), pinholeIntrinsic->h()));
+    sfm_data.views.emplace((IndexT)uid, std::make_shared<View>(stlplus::basename_part(*iter), (IndexT)uid, id, id, pinholeIntrinsic->w(), pinholeIntrinsic->h()));
     sfm_data.poses.emplace(id, pose);
     sfm_data.intrinsics.emplace(id, pinholeIntrinsic);
   }

--- a/src/openMVG/sfm/sfm_data_io_gt.hpp
+++ b/src/openMVG/sfm/sfm_data_io_gt.hpp
@@ -27,7 +27,7 @@ bool read_Strecha_Camera(const std::string & camName, cameras::Pinhole_Intrinsic
 @param[in] useUID, set to false to disable UID".
 @return Returns true if data has been read without errors
 **/
-bool readGt(const std::string sRootPath, SfM_Data & sfm_data, bool useUID = true);
+bool readGt(const std::string & sRootPath, SfM_Data & sfm_data, bool useUID = true);
 
 } // namespace sfm
 } // namespace openMVG

--- a/src/openMVG/sfm/sfm_data_io_gt.hpp
+++ b/src/openMVG/sfm/sfm_data_io_gt.hpp
@@ -192,7 +192,7 @@ bool readGt(const std::string sRootPath, SfM_Data & sfm_data)
     const size_t uid = computeUID(exifReader, sImgName);
 
     // Update intrinsics with width and height of image
-    sfm_data.views.emplace((IndexT)uid, std::make_shared<View>(stlplus::basename_part(*iter), (IndexT)uid, id, id, pinholeIntrinsic->w(), pinholeIntrinsic->h()));
+    sfm_data.views.emplace((IndexT)uid, std::make_shared<View>(stlplus::basename_part(*iter), id, id, id, pinholeIntrinsic->w(), pinholeIntrinsic->h()));
     sfm_data.poses.emplace(id, pose);
     sfm_data.intrinsics.emplace(id, pinholeIntrinsic);
   }

--- a/src/openMVG/sfm/sfm_data_io_gt.hpp
+++ b/src/openMVG/sfm/sfm_data_io_gt.hpp
@@ -1,4 +1,3 @@
-
 // Copyright (c) 2012, 2013, 2014 Pierre MOULON.
 
 // This Source Code Form is subject to the terms of the Mozilla Public
@@ -7,197 +6,26 @@
 
 #pragma once
 
-#include "sfm_data_io.hpp"
-
 #include "openMVG/geometry/pose3.hpp"
-#include "openMVG/exif/exif_IO_EasyExif.hpp"
+#include "openMVG/sfm/sfm_data.hpp"
 
-#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
-
-#include <fstream>
-#include <vector>
+#include <string>
 
 namespace openMVG {
 namespace sfm {
 
-static bool read_openMVG_Camera(const std::string & camName, cameras::Pinhole_Intrinsic & cam, geometry::Pose3 & pose)
-{
-  std::vector<double> val;
-  if (stlplus::extension_part(camName) == "bin")
-  {
-    std::ifstream in(camName.c_str(), std::ios::in|std::ios::binary);
-    if (!in.is_open())
-    {
-      std::cerr << "Error: failed to open file '" << camName << "' for reading" << std::endl;
-      return false;
-    }
-    val.resize(12);
-    in.read((char*)&val[0],(std::streamsize)12*sizeof(double));
-    if (in.fail())
-    {
-      val.clear();
-      return false;
-    }
-  }
-  else
-  {
-    std::ifstream ifs;
-    ifs.open( camName.c_str(), std::ifstream::in);
-    if (!ifs.is_open()) {
-      std::cerr << "Error: failed to open file '" << camName << "' for reading" << std::endl;
-      return false;
-    }
-    while (ifs.good())
-    {
-      double valT;
-      ifs >> valT;
-      if (!ifs.fail())
-        val.push_back(valT);
-    }
-  }
+bool read_openMVG_Camera(const std::string & camName, cameras::Pinhole_Intrinsic & cam, geometry::Pose3 & pose);
 
-  //Update the camera from file value
-  Mat34 P;
-  if (stlplus::extension_part(camName) == "bin")
-  {
-    P << val[0], val[3], val[6], val[9],
-      val[1], val[4], val[7], val[10],
-      val[2], val[5], val[8], val[11];
-  }
-  else
-  {
-    P << val[0], val[1], val[2], val[3],
-      val[4], val[5], val[6], val[7],
-      val[8], val[9], val[10], val[11];
-  }
-  Mat3 K, R;
-  Vec3 t;
-  KRt_From_P(P, &K, &R, &t);
-  cam = cameras::Pinhole_Intrinsic(0,0,K);
-  // K.transpose() is applied to give [R t] to the constructor instead of P = K [R t]
-  pose = geometry::Pose3(K.transpose() * P);
-  return true;
-}
-
-static bool read_Strecha_Camera(const std::string & camName, cameras::Pinhole_Intrinsic & cam, geometry::Pose3 & pose)
-{
-  std::ifstream ifs;
-  ifs.open( camName.c_str(), std::ifstream::in);
-  if (!ifs.is_open()) {
-    std::cerr << "Error: failed to open file '" << camName << "' for reading" << std::endl;
-    return false;
-  }
-  std::vector<double> val;
-  while (ifs.good() && !ifs.eof())
-  {
-    double valT;
-    ifs >> valT;
-    if (!ifs.fail())
-      val.push_back(valT);
-  }
-
-  if (!(val.size() == 3*3 +3 +3*3 +3 + 3 || val.size() == 26)) //Strecha cam
-  {
-    std::cerr << "File " << camName << " is not in Stretcha format ! " << std::endl;
-    return false;
-  }
-  Mat3 K, R;
-  K << val[0], val[1], val[2],
-    val[3], val[4], val[5],
-    val[6], val[7], val[8];
-  R << val[12], val[13], val[14],
-    val[15], val[16], val[17],
-    val[18], val[19], val[20];
-
-  Vec3 C (val[21], val[22], val[23]);
-  // R need to be transposed
-  cam = cameras::Pinhole_Intrinsic(0,0,K);
-  cam.setWidth(val[24]);
-  cam.setHeight(val[25]);
-  pose = geometry::Pose3(R.transpose(), C);
-  return true;
-}
+bool read_Strecha_Camera(const std::string & camName, cameras::Pinhole_Intrinsic & cam, geometry::Pose3 & pose);
 
 /**
 @brief Reads a set of Pinhole Cameras and its poses from a ground truth dataset.
 @param[in] sRootPath, the directory containing an image folder "images" and a GT folder "gt_dense_cameras".
 @param[out] sfm_data, the SfM_Data structure to put views/poses/intrinsics in.
+@param[in] useUID, set to false to disable UID".
 @return Returns true if data has been read without errors
 **/
-bool readGt(const std::string sRootPath, SfM_Data & sfm_data)
-{
-  // IF GT_Folder exists, perform evaluation of the quality of rotation estimates
-  const std::string sGTPath = stlplus::folder_down(sRootPath, "gt_dense_cameras");
-  if (!stlplus::is_folder(sGTPath))
-  {
-    std::cout << std::endl << "There is not valid GT data to read from " << sGTPath << std::endl;
-    return false;
-  }
-
-  // Switch between case to choose the file reader according to the file types in GT path
-  bool (*fcnReadCamPtr)(const std::string &, cameras::Pinhole_Intrinsic &, geometry::Pose3&);
-  std::string suffix;
-  if (!stlplus::folder_wildcard(sGTPath, "*.bin", true, true).empty())
-  {
-    std::cout << "\nusing openMVG Camera";
-    fcnReadCamPtr = &read_openMVG_Camera;
-    suffix = "bin";
-  }
-  else if (!stlplus::folder_wildcard(sGTPath, "*.camera", true, true).empty())
-  {
-    std::cout << "\nusing Strechas Camera";
-    fcnReadCamPtr = &read_Strecha_Camera;
-    suffix = "camera";
-  }
-  else
-  {
-    throw std::logic_error(std::string("No camera found in ") + sGTPath);
-  }
-
-  std::cout << std::endl << "Read rotation and translation estimates" << std::endl;
-  const std::string sImgPath = stlplus::folder_down(sRootPath, "images");
-  std::map< std::string, Mat3 > map_R_gt;
-  //Try to read .suffix camera (parse camera names)
-  std::vector<std::string> vec_camfilenames =
-    stlplus::folder_wildcard(sGTPath, "*."+suffix, true, true);
-  std::sort(vec_camfilenames.begin(), vec_camfilenames.end());
-  if (vec_camfilenames.empty())
-  {
-    std::cout << "No camera found in " << sGTPath << std::endl;
-    return false;
-  }
-  IndexT id = 0;
-  for (std::vector<std::string>::const_iterator iter = vec_camfilenames.begin();
-    iter != vec_camfilenames.end(); ++iter, ++id)
-  {
-    geometry::Pose3 pose;
-    std::shared_ptr<cameras::Pinhole_Intrinsic> pinholeIntrinsic = std::make_shared<cameras::Pinhole_Intrinsic>();
-    bool loaded = fcnReadCamPtr(stlplus::create_filespec(sGTPath, *iter), *pinholeIntrinsic.get(), pose);
-    if (!loaded)
-    {
-      std::cout << "Failed to load: " << *iter << std::endl;
-      return false;
-    }
-
-    const std::string sImgName = stlplus::basename_part(*iter);
-    const std::string sImgFile = stlplus::create_filespec(sImgPath, sImgName);
-
-    // Generate UID
-    if (!stlplus::file_exists(sImgFile))
-    {
-      throw std::logic_error("Impossible to generate UID from this file, because it does not exists: "+sImgFile);
-    }
-    exif::Exif_IO_EasyExif exifReader;
-    exifReader.open( sImgFile );
-    const size_t uid = computeUID(exifReader, sImgName);
-
-    // Update intrinsics with width and height of image
-    sfm_data.views.emplace((IndexT)uid, std::make_shared<View>(stlplus::basename_part(*iter), (IndexT)uid, id, id, pinholeIntrinsic->w(), pinholeIntrinsic->h()));
-    sfm_data.poses.emplace(id, pose);
-    sfm_data.intrinsics.emplace(id, pinholeIntrinsic);
-  }
-  return true;
-}
+bool readGt(const std::string sRootPath, SfM_Data & sfm_data, bool useUID = true);
 
 } // namespace sfm
 } // namespace openMVG

--- a/src/software/Localization/main_cameraLocalizer.cpp
+++ b/src/software/Localization/main_cameraLocalizer.cpp
@@ -436,15 +436,7 @@ int main(int argc, char** argv)
     {
       POPART_CERR("Unable to localize frame " << frameCounter);
 #if HAVE_ALEMBIC
-      if(frameCounter == 0)
-      {
-        // No previous pose, use the identity matrix
-        exporter.addCameraKeyframe(geometry::Pose3(), &queryIntrinsics, currentImgName, frameCounter, frameCounter);
-      }
-      else
-      {
-        exporter.jumpKeyframe();
-      }
+      exporter.jumpKeyframe(currentImgName);
 #endif
     }
     ++frameCounter;
@@ -494,7 +486,7 @@ int main(int argc, char** argv)
         }
         else
         {
-          exporterBA.jumpKeyframe();
+          exporterBA.jumpKeyframe(currentImgName);
         }
         idx++;
       }

--- a/src/software/Localization/main_cameraLocalizer.cpp
+++ b/src/software/Localization/main_cameraLocalizer.cpp
@@ -436,7 +436,15 @@ int main(int argc, char** argv)
     {
       POPART_CERR("Unable to localize frame " << frameCounter);
 #if HAVE_ALEMBIC
-      exporter.jumpKeyframe();
+      if(frameCounter == 0)
+      {
+        // No previous pose, use the identity matrix
+        exporter.addCameraKeyframe(geometry::Pose3(), &queryIntrinsics, currentImgName, frameCounter, frameCounter);
+      }
+      else
+      {
+        exporter.jumpKeyframe();
+      }
 #endif
     }
     ++frameCounter;

--- a/src/software/SfM/CMakeLists.txt
+++ b/src/software/SfM/CMakeLists.txt
@@ -149,13 +149,15 @@ TARGET_LINK_LIBRARIES(openMVG_main_ComputeSfM_DataColor
   stlplus
   )
 
-ADD_EXECUTABLE(openMVG_main_ConvertAnimatedCamera main_ConvertAnimatedCamera.cpp)
-TARGET_LINK_LIBRARIES(openMVG_main_ConvertAnimatedCamera
-  openMVG_system
-  openMVG_features
-  openMVG_sfm
-  stlplus
+IF(OpenMVG_USE_ALEMBIC)
+  ADD_EXECUTABLE(openMVG_main_ConvertAnimatedCamera main_ConvertAnimatedCamera.cpp)
+  TARGET_LINK_LIBRARIES(openMVG_main_ConvertAnimatedCamera
+    openMVG_system
+    openMVG_features
+    openMVG_sfm
+    stlplus
   )
+ENDIF(OpenMVG_USE_ALEMBIC)
 
 # Installation rules
 SET_PROPERTY(TARGET openMVG_main_IncrementalSfM PROPERTY FOLDER OpenMVG/software)
@@ -172,8 +174,10 @@ SET_PROPERTY(TARGET openMVG_main_ComputeStructureFromKnownPoses PROPERTY FOLDER 
 INSTALL(TARGETS openMVG_main_ComputeStructureFromKnownPoses DESTINATION bin/)
 SET_PROPERTY(TARGET openMVG_main_ComputeSfM_DataColor PROPERTY FOLDER OpenMVG/software)
 INSTALL(TARGETS openMVG_main_ComputeSfM_DataColor DESTINATION bin/)
-SET_PROPERTY(TARGET openMVG_main_ConvertAnimatedCamera PROPERTY FOLDER OpenMVG/software)
-INSTALL(TARGETS openMVG_main_ConvertAnimatedCamera DESTINATION bin/)
+IF(OpenMVG_USE_ALEMBIC)
+  SET_PROPERTY(TARGET openMVG_main_ConvertAnimatedCamera PROPERTY FOLDER OpenMVG/software)
+  INSTALL(TARGETS openMVG_main_ConvertAnimatedCamera DESTINATION bin/)
+ENDIF(OpenMVG_USE_ALEMBIC)
 
 ###
 # SfM tools to visualize feature tracking data

--- a/src/software/SfM/CMakeLists.txt
+++ b/src/software/SfM/CMakeLists.txt
@@ -149,6 +149,14 @@ TARGET_LINK_LIBRARIES(openMVG_main_ComputeSfM_DataColor
   stlplus
   )
 
+ADD_EXECUTABLE(openMVG_main_ConvertAnimatedCamera main_ConvertAnimatedCamera.cpp)
+TARGET_LINK_LIBRARIES(openMVG_main_ConvertAnimatedCamera
+  openMVG_system
+  openMVG_features
+  openMVG_sfm
+  stlplus
+  )
+
 # Installation rules
 SET_PROPERTY(TARGET openMVG_main_IncrementalSfM PROPERTY FOLDER OpenMVG/software)
 INSTALL(TARGETS openMVG_main_IncrementalSfM DESTINATION bin/)
@@ -164,6 +172,8 @@ SET_PROPERTY(TARGET openMVG_main_ComputeStructureFromKnownPoses PROPERTY FOLDER 
 INSTALL(TARGETS openMVG_main_ComputeStructureFromKnownPoses DESTINATION bin/)
 SET_PROPERTY(TARGET openMVG_main_ComputeSfM_DataColor PROPERTY FOLDER OpenMVG/software)
 INSTALL(TARGETS openMVG_main_ComputeSfM_DataColor DESTINATION bin/)
+SET_PROPERTY(TARGET openMVG_main_ConvertAnimatedCamera PROPERTY FOLDER OpenMVG/software)
+INSTALL(TARGETS openMVG_main_ConvertAnimatedCamera DESTINATION bin/)
 
 ###
 # SfM tools to visualize feature tracking data

--- a/src/software/SfM/main_ConvertAnimatedCamera.cpp
+++ b/src/software/SfM/main_ConvertAnimatedCamera.cpp
@@ -47,7 +47,7 @@ int main(int argc, char **argv)
   }
 
   // init alembic exporter
-  dataio::AlembicExporter exporter( sSfM_Data_Filename_Out.c_str() );
+  dataio::AlembicExporter exporter( sSfM_Data_Filename_Out );
   exporter.initAnimatedCamera("camera");
 
   for(const auto &iter : sfm_data.GetViews())

--- a/src/software/SfM/main_ConvertAnimatedCamera.cpp
+++ b/src/software/SfM/main_ConvertAnimatedCamera.cpp
@@ -1,0 +1,65 @@
+#include "openMVG/sfm/sfm.hpp"
+#include <openMVG/sfm/AlembicExporter.hpp>
+#include "third_party/cmdLine/cmdLine.h"
+#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
+#include <string>
+#include <vector>
+
+using namespace openMVG;
+using namespace openMVG::sfm;
+
+int main(int argc, char **argv)
+{
+  CmdLine cmd;
+
+  std::string
+    sSfM_Data_Filename_In,
+    sSfM_Data_Filename_Out;
+
+  cmd.add(make_option('i', sSfM_Data_Filename_In, "input_file"));
+  cmd.add(make_option('o', sSfM_Data_Filename_Out, "output_file"));
+
+  try {
+      if (argc == 1) throw std::string("Invalid command line parameter.");
+      cmd.process(argc, argv);
+  } catch(const std::string& s) {
+      std::cerr << "Usage: " << argv[0] << '\n'
+        << "[-i|--input_file] path to the input SfM_Data scene\n"
+        << "[-o|--output_file] path to the output SfM_Data scene\n"
+        << "\t .json, .bin, .xml, .ply, .baf, .abc\n"
+        << std::endl;
+
+      std::cerr << s << std::endl;
+      return EXIT_FAILURE;
+  }
+
+  if (sSfM_Data_Filename_In.empty() || sSfM_Data_Filename_Out.empty())
+  {
+    std::cerr << "Invalid input or output filename." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // Load input SfM_Data scene
+  SfM_Data sfm_data;
+  if (!Load(sfm_data, sSfM_Data_Filename_In, ESfM_Data(ALL)))
+  {
+    std::cerr << std::endl
+      << "The input SfM_Data file \"" << sSfM_Data_Filename_In << "\" cannot be read." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // init alembic exporter
+  dataio::AlembicExporter exporter( sSfM_Data_Filename_Out.c_str() );
+  exporter.initAnimatedCamera("camera");
+
+  for(const auto &iter : sfm_data.GetViews())
+  {
+    const auto &view = iter.second;
+    const geometry::Pose3 pose_gt = sfm_data.GetPoses().at(view->id_pose);
+    std::shared_ptr<cameras::IntrinsicBase> intrinsic_gt = std::make_shared<cameras::Pinhole_Intrinsic>();
+    intrinsic_gt = sfm_data.GetIntrinsics().at(view->id_intrinsic);
+    exporter.addCameraKeyframe(pose_gt, dynamic_cast<cameras::Pinhole_Intrinsic*>(intrinsic_gt.get()), view->s_Img_path, view->id_view, view->id_intrinsic);
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/src/software/SfM/main_ConvertAnimatedCamera.cpp
+++ b/src/software/SfM/main_ConvertAnimatedCamera.cpp
@@ -1,7 +1,7 @@
 #include <openMVG/sfm/AlembicExporter.hpp>
 #include <openMVG/sfm/sfm_data_io_gt.hpp>
-#include "third_party/cmdLine/cmdLine.h"
-#include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
+#include <third_party/cmdLine/cmdLine.h>
+#include <third_party/stlplus3/filesystemSimplified/file_system.hpp>
 #include <string>
 #include <vector>
 

--- a/src/software/SfM/main_ConvertAnimatedCamera.cpp
+++ b/src/software/SfM/main_ConvertAnimatedCamera.cpp
@@ -1,5 +1,5 @@
-#include "openMVG/sfm/sfm.hpp"
 #include <openMVG/sfm/AlembicExporter.hpp>
+#include <openMVG/sfm/sfm_data_io_gt.hpp>
 #include "third_party/cmdLine/cmdLine.h"
 #include "third_party/stlplus3/filesystemSimplified/file_system.hpp"
 #include <string>
@@ -39,7 +39,7 @@ int main(int argc, char **argv)
 
   // Load input SfM_Data scene
   SfM_Data sfm_data;
-  if (!Load(sfm_data, sSfM_Data_Filename_In, ESfM_Data(ALL)))
+  if (!readGt(sSfM_Data_Filename_In, sfm_data, false))
   {
     std::cerr << std::endl
       << "The input SfM_Data file \"" << sSfM_Data_Filename_In << "\" cannot be read." << std::endl;

--- a/src/software/SfM/main_ConvertAnimatedCamera.cpp
+++ b/src/software/SfM/main_ConvertAnimatedCamera.cpp
@@ -23,11 +23,9 @@ int main(int argc, char **argv)
       if (argc == 1) throw std::string("Invalid command line parameter.");
       cmd.process(argc, argv);
   } catch(const std::string& s) {
-      std::cerr << "Usage: " << argv[0] << '\n'
-        << "[-i|--input_file] path to the input SfM_Data scene\n"
-        << "[-o|--output_file] path to the output SfM_Data scene\n"
-        << "\t .json, .bin, .xml, .ply, .baf, .abc\n"
-        << std::endl;
+      std::cerr << "Usage: " << argv[0] << std::endl;
+      std::cerr  << "[-i|--input_file] path to the input ground truth folder" << std::endl;
+      std::cerr << "[-o|--output_file] path to the output Alembic file" << std::endl;
 
       std::cerr << s << std::endl;
       return EXIT_FAILURE;
@@ -60,6 +58,5 @@ int main(int argc, char **argv)
     intrinsic_gt = sfm_data.GetIntrinsics().at(view->id_intrinsic);
     exporter.addCameraKeyframe(pose_gt, dynamic_cast<cameras::Pinhole_Intrinsic*>(intrinsic_gt.get()), view->s_Img_path, view->id_view, view->id_intrinsic);
   }
-
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This PR fixes the sampling system during Alembic import. Instead of using time samples to retrieve the poses of the cameras, it just uses indices to access to each sample. This avoid issues given by (possible) different frame rates of the animations.

There is also a debug program that converts a ground truth folder-format (containing subfolders `gt` and `images`) in an Alembic file.

It also fixes the bug poparteu/openMVG#166 (localization application crashed due to Alembic if first frame is not localized). (connect to poparteu/openMVG#166)