### PR TITLE
[sfm] bugfix localize loransac, wrong normalization for threshold

### DIFF
--- a/src/openMVG/sfm/pipelines/localization/SfM_Localizer.cpp
+++ b/src/openMVG/sfm/pipelines/localization/SfM_Localizer.cpp
@@ -139,7 +139,7 @@ bool SfM_Localizer::Localize
         // value, the scorer should be not aware of the fact that we treat squared errors
         // and normalization inside the kernel
         // @todo refactor, maybe move scorer directly inside the kernel
-        const double threshold = resection_data.error_max * resection_data.error_max / (kernel.normalizer2()(0, 0) * kernel.normalizer2()(0, 0));
+        const double threshold = resection_data.error_max * resection_data.error_max * (kernel.normalizer2()(0, 0) * kernel.normalizer2()(0, 0));
         robust::ScorerEvaluator<KernelType> scorer(threshold);
         P = robust::LO_RANSAC(kernel, scorer, &resection_data.vec_inliers);
         break;


### PR DESCRIPTION
kernel.normalizer2 is the inverse of K, so we need to multiply by the inverse of the focal.
This implementation really sucks, as mentioned in the comment... need refactoring asap!!