### PR TITLE
[WIP] some fixes for cctags

### DIFF
--- a/src/openMVG/calibration/CMakeLists.txt
+++ b/src/openMVG/calibration/CMakeLists.txt
@@ -14,7 +14,7 @@ set(calibration_files_sources
 ADD_LIBRARY(openMVG_calibration
   ${calibration_files_headers}
   ${calibration_files_sources})
-TARGET_LINK_LIBRARIES(openMVG_calibration openMVG_image openMVG_dataio ${BOOST_LIBRARIES}  ${OpenCV_LIBS})
+TARGET_LINK_LIBRARIES(openMVG_calibration openMVG_image openMVG_system openMVG_dataio ${BOOST_LIBRARIES}  ${OpenCV_LIBS})
 IF(OpenMVG_USE_CCTAG)
   TARGET_LINK_LIBRARIES(openMVG_calibration ${CCTAG_LIBRARIES})
 ENDIF(OpenMVG_USE_CCTAG)

--- a/src/openMVG/calibration/calibration.hpp
+++ b/src/openMVG/calibration/calibration.hpp
@@ -74,21 +74,21 @@ bool runCalibration(const std::vector<std::vector<cv::Point2f> >& imagePoints,
  * @return True if the calibration is a success, otherwise false.
  */
 bool calibrationIterativeOptimization(std::vector<std::vector<cv::Point2f> >& calibImagePoints,
-                        std::vector<std::vector<cv::Point3f> >& calibObjectPoints,
-                        const cv::Size& imageSize,
-                        float aspectRatio,
-                        int cvCalibFlags,
-                        cv::Mat& cameraMatrix,
-                        cv::Mat& distCoeffs,
-                        std::vector<cv::Mat>& rvecs,
-                        std::vector<cv::Mat>& tvecs,
-                        std::vector<float>& reprojErrs,
-                        double& totalAvgErr,
-                        const double& maxTotalAvgErr,
-                        const std::size_t& minInputFrames,
-                        std::vector<std::size_t>& calibInputFrames,
-                        std::vector<float>& calibImageScore,
-                        std::vector<std::size_t>& rejectInputFrames);
+                                      std::vector<std::vector<cv::Point3f> >& calibObjectPoints,
+                                      const cv::Size& imageSize,
+                                      float aspectRatio,
+                                      int cvCalibFlags,
+                                      cv::Mat& cameraMatrix,
+                                      cv::Mat& distCoeffs,
+                                      std::vector<cv::Mat>& rvecs,
+                                      std::vector<cv::Mat>& tvecs,
+                                      std::vector<float>& reprojErrs,
+                                      double& totalAvgErr,
+                                      const double& maxTotalAvgErr,
+                                      const std::size_t& minInputFrames,
+                                      std::vector<std::size_t>& calibInputFrames,
+                                      std::vector<float>& calibImageScore,
+                                      std::vector<std::size_t>& rejectInputFrames);
 
 }//namespace calibration
 }//namespace openMVG

--- a/src/openMVG/calibration/patternDetect.cpp
+++ b/src/openMVG/calibration/patternDetect.cpp
@@ -1,5 +1,7 @@
 #include "patternDetect.hpp"
 
+#include <openMVG/system/timer.hpp>
+
 #include <boost/program_options.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
 
@@ -60,47 +62,39 @@ std::ostream& operator<<(std::ostream &stream, const Pattern pattern)
 bool findPattern(const Pattern& pattern, const cv::Mat& viewGray, const cv::Size& boardSize, std::vector<cv::Point2f>& pointbuf)
 {
   bool found = false;
-  std::clock_t startCh;
-  double durationCh = 0.0;
+  system::Timer durationCh;
 
   switch (pattern)
   {
   case CHESSBOARD:
-    startCh = std::clock();
 
     found = cv::findChessboardCorners(viewGray, boardSize, pointbuf,
                                       CV_CALIB_CB_ADAPTIVE_THRESH | CV_CALIB_CB_FAST_CHECK | CV_CALIB_CB_NORMALIZE_IMAGE);
-    durationCh = (std::clock() - startCh) / (double) CLOCKS_PER_SEC;
-    std::cout << "Find chessboard corners' duration: " << durationCh << std::endl;
+    std::cout << "Find chessboard corners' duration: " << durationCh.elapsedMs() << "ms" << std::endl;
 
     // improve the found corners' coordinate accuracy
     if (found)
     {
-      startCh = std::clock();
+      durationCh.reset();
       cv::cornerSubPix(viewGray, pointbuf, cv::Size(11, 11), cv::Size(-1, -1),
                        cv::TermCriteria(CV_TERMCRIT_EPS + CV_TERMCRIT_ITER, 30, 0.1));
 
-      durationCh = (std::clock() - startCh) / (double) CLOCKS_PER_SEC;
-      std::cout << "Refine chessboard corners' duration: " << durationCh << std::endl;
+      std::cout << "Refine chessboard corners' duration: " << durationCh.elapsedMs() << "ms" << std::endl;
     }
     break;
 
   case CIRCLES_GRID:
-    startCh = std::clock();
 
     found = cv::findCirclesGrid(viewGray, boardSize, pointbuf);
 
-    durationCh = (std::clock() - startCh) / (double) CLOCKS_PER_SEC;
-    std::cout << "Find circles grid duration: " << durationCh << std::endl;
+    std::cout << "Find circles grid duration: " << durationCh.elapsedMs() << "ms" << std::endl;
     break;
 
   case ASYMMETRIC_CIRCLES_GRID:
-    startCh = std::clock();
 
     found = cv::findCirclesGrid(viewGray, boardSize, pointbuf, cv::CALIB_CB_ASYMMETRIC_GRID);
 
-    durationCh = (std::clock() - startCh) / (double) CLOCKS_PER_SEC;
-    std::cout << "Find asymmetric circles grid duration: " << durationCh << std::endl;
+    std::cout << "Find asymmetric circles grid duration: " << durationCh.elapsedMs() << "ms" << std::endl;
     break;
 
 #ifdef HAVE_CCTAG

--- a/src/openMVG/dataio/ImageFeed.cpp
+++ b/src/openMVG/dataio/ImageFeed.cpp
@@ -1,10 +1,3 @@
-/* 
- * File:   ImageFeed.cpp
- * Author: sgaspari
- * 
- * Created on September 28, 2015, 10:31 AM
- */
-
 #include "ImageFeed.hpp"
 #include <openMVG/sfm/sfm_data.hpp>
 #include <openMVG/sfm/sfm_data_io.hpp>
@@ -275,7 +268,7 @@ bool ImageFeed::FeederImpl::goToFrame(const unsigned int frame)
   // Reconstruction mode
   if(_sfmMode)
   {
-    if(frame < 0 || frame >= _sfmdata.GetViews().size())
+    if(frame >= _sfmdata.GetViews().size())
     {
       _viewIterator = _sfmdata.GetViews().end();
       std::cerr << "The current frame is out of the range." << std::endl;
@@ -289,7 +282,7 @@ bool ImageFeed::FeederImpl::goToFrame(const unsigned int frame)
   {
     _currentImageIndex = frame;
     // Image list mode
-    if(frame < 0 || frame >= _images.size())
+    if(frame >= _images.size())
     {
       std::cerr << "The current frame is out of the range." << std::endl;
       return false;
@@ -313,7 +306,7 @@ bool ImageFeed::FeederImpl::goToNextFrame()
   {
     ++_currentImageIndex;
     std::cout << "next frame " << _currentImageIndex << std::endl;
-    if(_currentImageIndex < 0 || _currentImageIndex >= _images.size())
+    if(_currentImageIndex >= _images.size())
       return false;
   }
   return true;

--- a/src/openMVG/features/cctag/CCTAG_describer.cpp
+++ b/src/openMVG/features/cctag/CCTAG_describer.cpp
@@ -1,8 +1,7 @@
 #include "CCTAG_describer.hpp"
 
-#include <cctag/view.hpp>
 #include <cctag/ICCTag.hpp>
-#include <cctag/logtime.hpp>
+#include <cctag/utils/LogTime.hpp>
 //#define CPU_ADAPT_OF_GPU_PART //todo: #ifdef depreciated
 #ifdef CPU_ADAPT_OF_GPU_PART    
   #include "cctag/progBase/MemoryPool.hpp"

--- a/src/openMVG/localization/CCTagLocalizer.cpp
+++ b/src/openMVG/localization/CCTagLocalizer.cpp
@@ -443,20 +443,35 @@ bool CCTagLocalizer::localize(const std::unique_ptr<features::Regions> &genQuery
     if(!param->_visualDebug.empty() && !imagePath.empty())
     {
       const sfm::View *mview = _sfm_data.GetViews().at(indexKeyFrame).get();
-      const std::string queryimage = bfs::path(imagePath).stem().string();
+      const std::string queryImage = bfs::path(imagePath).stem().string();
       const std::string matchedImage = bfs::path(mview->s_Img_path).stem().string();
       const std::string matchedPath = (bfs::path(_sfm_data.s_root_path) /  bfs::path(mview->s_Img_path)).string();
+
+      // the directory where to save the feature matches
+      const auto baseDir = bfs::path(param->_visualDebug) / queryImage;
+      if((!bfs::exists(baseDir)))
+      {
+        POPART_COUT("created " << baseDir.string());
+        bfs::create_directories(baseDir);
+      }
       
+      // the final filename for the output svg file as a composition of the query
+      // image and the matched image
+      auto outputName = baseDir / queryImage;
+      outputName += "_";
+      outputName += matchedImage;
+      outputName += ".svg";
       
+      const bool showNotMatched = true;
       features::saveCCTagMatches2SVG(imagePath, 
-                           imageSize, 
-                           queryRegions,
-                           matchedPath,
-                           std::make_pair(mview->ui_width, mview->ui_height), 
-                           _regions_per_view[indexKeyFrame]._regions,
-                           vec_featureMatches,
-                           param->_visualDebug+"/"+queryimage+"_"+matchedImage+".svg",
-                           true ); //showNotMatched
+                                     imageSize, 
+                                     queryRegions,
+                                     matchedPath,
+                                     std::make_pair(mview->ui_width, mview->ui_height), 
+                                     _regions_per_view[indexKeyFrame]._regions,
+                                     vec_featureMatches,
+                                     outputName.string(),
+                                     showNotMatched ); 
     }
     
     if ( vec_featureMatches.size() < 3 )

--- a/src/openMVG/localization/CCTagLocalizer.cpp
+++ b/src/openMVG/localization/CCTagLocalizer.cpp
@@ -849,14 +849,10 @@ bool CCTagLocalizer::localizeRig_naive(const std::vector<std::unique_ptr<feature
     //set the pose
     rigPose = vec_localizationResults[0].getPose();
   }
-  
-  // if only one camera has been localized
-  if(numLocalizedCam == 1)
+  else
   {
-    // all the other cameras have not been localized just return the result of the 
-    // localized one
-    
-    // find the index of the localized camera
+
+    // find the index of the first localized camera
     const std::size_t idx = std::distance(isLocalized.begin(), 
                                           std::find(isLocalized.begin(), isLocalized.end(), true));
     
@@ -864,6 +860,7 @@ bool CCTagLocalizer::localizeRig_naive(const std::vector<std::unique_ptr<feature
     // better safe than sorry
     assert(idx < isLocalized.size());
     
+    POPART_COUT("Index of the first localized camera: " << idx);
     // if the only localized camera is the main camera
     if(idx==0)
     {

--- a/src/openMVG/localization/CCTagLocalizer.cpp
+++ b/src/openMVG/localization/CCTagLocalizer.cpp
@@ -266,6 +266,8 @@ bool CCTagLocalizer::localize(const std::unique_ptr<features::Regions> &genQuery
   // it automatically throws an exception if the cast does not work
   features::CCTAG_Regions &queryRegions = *dynamic_cast<features::CCTAG_Regions*> (genQueryRegions.get());
   
+  // a map containing for each pair <pt3D_id, pt2D_id> the number of times that 
+  // the association has been seen
   std::map< std::pair<IndexT, IndexT>, std::size_t > occurences;
   sfm::Image_Localizer_Match_Data resectionData;
   
@@ -480,7 +482,10 @@ bool CCTagLocalizer::localizeRig_opengv(const std::vector<std::unique_ptr<featur
   {
     throw std::invalid_argument("The CCTag localizer parameters are not in the right format.");
   }
-
+  
+  // each element of the vector is a map containing for each pair <pt3D_id, pt2D_id> 
+  // the number of times that the association has been seen. One element fo the 
+  // vector for each camera.
   std::vector<std::map< pair<IndexT, IndexT>, std::size_t > > vec_occurrences(numCams);
   std::vector<Mat> vec_pts3D(numCams);
   std::vector<Mat> vec_pts2D(numCams);

--- a/src/openMVG/localization/CCTagLocalizer.cpp
+++ b/src/openMVG/localization/CCTagLocalizer.cpp
@@ -431,7 +431,7 @@ bool CCTagLocalizer::localize(const std::unique_ptr<features::Regions> &genQuery
   POPART_COUT_DEBUG("nearestKeyFrames.size() = " << nearestKeyFrames.size());
   for(const IndexT indexKeyFrame : nearestKeyFrames)
   {
-    POPART_COUT("[localization]\tProcessing nearest kframe " << indexKeyFrame 
+    POPART_COUT("[matching]\tProcessing nearest kframe " << indexKeyFrame 
             << " (" << _sfm_data.GetViews().at(indexKeyFrame)->s_Img_path << ")");
     const Reconstructed_RegionsCCTag& matchedRegions = _regions_per_view[indexKeyFrame];
     
@@ -475,10 +475,10 @@ bool CCTagLocalizer::localize(const std::unique_ptr<features::Regions> &genQuery
     
     if ( vec_featureMatches.size() < 3 )
     {
-      POPART_COUT("[localization]\tSkipping kframe " << indexKeyFrame << " as it contains only "<< vec_featureMatches.size()<<" matches");
+      POPART_COUT("[matching]\tSkipping kframe " << indexKeyFrame << " as it contains only "<< vec_featureMatches.size()<<" matches");
       continue;
     }
-    POPART_COUT("[localization]\tFound "<< vec_featureMatches.size()<<" matches");
+    POPART_COUT("[matching]\tFound "<< vec_featureMatches.size()<<" matches");
     
     // D. recover the 2D-3D associations from the matches 
     // Each matched feature in the current similar image is associated to a 3D point,
@@ -924,7 +924,7 @@ void CCTagLocalizer::getAllAssociations(const features::CCTAG_Regions &queryRegi
     // Matching
     std::vector<matching::IndMatch> vec_featureMatches;
     viewMatching(queryRegions, _regions_per_view.at(indexKeyFrame)._regions, vec_featureMatches);
-    POPART_COUT("[localization]\tFound "<< vec_featureMatches.size() <<" matches.");
+    POPART_COUT("matching]\tFound "<< vec_featureMatches.size() <<" matches.");
     
     if(!param._visualDebug.empty() && !imagePath.empty())
     {
@@ -985,7 +985,7 @@ void CCTagLocalizer::getAllAssociations(const features::CCTAG_Regions &queryRegi
   }
       
   const size_t numCollectedPts = occurences.size();
-  POPART_COUT("[localization]\tCollected "<< numCollectedPts <<" associations.");
+  POPART_COUT("[matching]\tCollected "<< numCollectedPts <<" associations.");
   
   {
     // just debugging statistics, this block can be safely removed    
@@ -994,7 +994,7 @@ void CCTagLocalizer::getAllAssociations(const features::CCTAG_Regions &queryRegi
     {
       const auto &key = idx.first;
       const auto &value = idx.second;
-       POPART_COUT("[localization]\tAssociations "
+       POPART_COUT("[matching]\tAssociations "
                << key.first << "," << key.second <<"] found " 
                << value << " times.");
        if(value > maxOcc)

--- a/src/openMVG/localization/CCTagLocalizer.cpp
+++ b/src/openMVG/localization/CCTagLocalizer.cpp
@@ -351,12 +351,7 @@ bool CCTagLocalizer::localize(const std::unique_ptr<features::Regions> &genQuery
 
   if(!param->_visualDebug.empty() && !imagePath.empty())
   {
-//    namespace bfs = boost::filesystem;
-//    features::saveFeatures2SVG(imagePath,
-//                              imageSize,
-//                              resectionData.pt2D,
-//                              param._visualDebug + "/" + bfs::path(imagePath).stem().string() + ".associations.svg",
-//                              &resectionData.vec_inliers);
+    //@todo save image with cctag with different code color for inliers
   }
   
   POPART_COUT("[poseEstimation]\tPose estimation took " << timer.elapsedMs() << "ms.");

--- a/src/openMVG/localization/CCTagLocalizer.cpp
+++ b/src/openMVG/localization/CCTagLocalizer.cpp
@@ -202,11 +202,11 @@ bool CCTagLocalizer::loadReconstructionDescriptors(const sfm::SfM_Data & sfm_dat
 }
 
 bool CCTagLocalizer::localize(const image::Image<unsigned char> & imageGrey,
-                const LocalizerParameters *parameters,
-                bool useInputIntrinsics,
-                cameras::Pinhole_Intrinsic_Radial_K3 &queryIntrinsics,
-                LocalizationResult & localizationResult, 
-                const std::string& imagePath /* = std::string() */)
+                              const LocalizerParameters *parameters,
+                              bool useInputIntrinsics,
+                              cameras::Pinhole_Intrinsic_Radial_K3 &queryIntrinsics,
+                              LocalizationResult & localizationResult, 
+                              const std::string& imagePath)
 {
   namespace bfs = boost::filesystem;
   
@@ -231,9 +231,9 @@ bool CCTagLocalizer::localize(const image::Image<unsigned char> & imageGrey,
     
     // just debugging -- save the svg image with detected cctag
     features::saveCCTag2SVG(imagePath, 
-                  imageSize, 
-                  queryRegions, 
-                  param->_visualDebug+"/"+bfs::path(imagePath).stem().string()+".svg");
+                            imageSize, 
+                            queryRegions, 
+                            param->_visualDebug+"/"+bfs::path(imagePath).stem().string()+".svg");
   }
 
   return localize(tmpQueryRegions,
@@ -368,7 +368,7 @@ bool CCTagLocalizer::localize(const std::unique_ptr<features::Regions> &genQuery
     {
       residualMin = resectionDataTemp.error_max;
       indexBestKeyFrame = indexKeyFrame;
-      // Update best inital pose.
+      // Update best initial pose.
       bestPose = poseTemp;
       bestResectionData = resectionDataTemp;
       std::swap(bestAssociationIDs, associationIDsTemp);
@@ -812,12 +812,11 @@ void CCTagLocalizer::getAllAssociations(const features::CCTAG_Regions &queryRegi
 
 
 
-void kNearestKeyFrames(
-          const features::CCTAG_Regions & queryRegions,
-          const CCTagRegionsPerViews & regionsPerView,
-          std::size_t nNearestKeyFrames,
-          std::vector<IndexT> & kNearestFrames,
-          const float similarityThreshold /*=.0f*/)
+void kNearestKeyFrames(const features::CCTAG_Regions & queryRegions,
+                       const CCTagRegionsPerViews & regionsPerView,
+                       std::size_t nNearestKeyFrames,
+                       std::vector<IndexT> & kNearestFrames,
+                       const float similarityThreshold /*=.0f*/)
 {
   kNearestFrames.clear();
   
@@ -848,10 +847,9 @@ void kNearestKeyFrames(
   }
 }
  
-void viewMatching(
-        const features::CCTAG_Regions & regionsA,
-        const features::CCTAG_Regions & regionsB,
-        std::vector<matching::IndMatch> & vec_featureMatches)
+void viewMatching(const features::CCTAG_Regions & regionsA,
+                  const features::CCTAG_Regions & regionsB,
+                  std::vector<matching::IndMatch> & vec_featureMatches)
 {
   vec_featureMatches.clear();
   
@@ -875,9 +873,8 @@ void viewMatching(
  
  
  
-float viewSimilarity(
-        const features::CCTAG_Regions & regionsA,
-        const features::CCTAG_Regions & regionsB)
+float viewSimilarity(const features::CCTAG_Regions & regionsA,
+                     const features::CCTAG_Regions & regionsB)
 {
   assert(regionsA.DescriptorLength() == regionsB.DescriptorLength()); 
   
@@ -888,8 +885,7 @@ float viewSimilarity(
   return (descriptorViewA & descriptorViewB).count();
 }
 
-std::bitset<128> constructCCTagViewDescriptor(
-        const std::vector<CCTagDescriptor> & vCCTagDescriptors)
+std::bitset<128> constructCCTagViewDescriptor(const std::vector<CCTagDescriptor> & vCCTagDescriptors)
 {
   std::bitset<128> descriptorView;
   for(const auto & cctagDescriptor : vCCTagDescriptors )

--- a/src/openMVG/localization/CCTagLocalizer.cpp
+++ b/src/openMVG/localization/CCTagLocalizer.cpp
@@ -295,8 +295,6 @@ bool CCTagLocalizer::localizeAllAssociations(const std::unique_ptr<features::Reg
   timer.reset();
   // estimate the pose
   resectionData.error_max = param->_errorMax;
-  POPART_COUT("pt2D\n"<<resectionData.pt2D);
-  POPART_COUT("pt3D\n"<<resectionData.pt3D);
   POPART_COUT("[poseEstimation]\tEstimating camera pose...");
   const bool bResection = sfm::SfM_Localizer::Localize(imageSize,
                                                       // pass the input intrinsic if they are valid, null otherwise

--- a/src/openMVG/localization/CCTagLocalizer.cpp
+++ b/src/openMVG/localization/CCTagLocalizer.cpp
@@ -239,7 +239,8 @@ bool CCTagLocalizer::localize(const image::Image<unsigned char> & imageGrey,
                             param->_visualDebug+"/"+bfs::path(imagePath).stem().string()+".svg");
   }
 
-  return localize(tmpQueryRegions,
+//  return localize(tmpQueryRegions,
+  return localizeAllAssociations(tmpQueryRegions,
                   imageSize,
                   parameters,
                   useInputIntrinsics,

--- a/src/openMVG/localization/CCTagLocalizer.cpp
+++ b/src/openMVG/localization/CCTagLocalizer.cpp
@@ -218,6 +218,7 @@ bool CCTagLocalizer::localize(const image::Image<unsigned char> & imageGrey,
   // extract descriptors and features from image
   POPART_COUT("[features]\tExtract CCTag from query image");
   std::unique_ptr<features::Regions> tmpQueryRegions(new features::CCTAG_Regions());
+  _image_describer.Set_configuration_preset(param->_featurePreset);
   _image_describer.Describe(imageGrey, tmpQueryRegions);
   POPART_COUT("[features]\tExtract CCTAG done: found " << tmpQueryRegions->RegionCount() << " features");
   
@@ -446,6 +447,7 @@ bool CCTagLocalizer::localizeRig(const std::vector<image::Image<unsigned char> >
     // extract descriptors and features from each image
     vec_queryRegions[i] = std::unique_ptr<features::Regions>(new features::CCTAG_Regions());
     POPART_COUT("[features]\tExtract CCTag from query image...");
+    _image_describer.Set_configuration_preset(param->_featurePreset);
     _image_describer.Describe(vec_imageGrey[i], vec_queryRegions[i]);
     POPART_COUT("[features]\tExtract CCTAG done: found " <<  vec_queryRegions[i]->RegionCount() << " features");
     // add the image size for this image

--- a/src/openMVG/localization/CCTagLocalizer.hpp
+++ b/src/openMVG/localization/CCTagLocalizer.hpp
@@ -72,7 +72,7 @@ public:
                                 bool useInputIntrinsics,
                                 cameras::Pinhole_Intrinsic_Radial_K3 &queryIntrinsics,
                                 LocalizationResult & localizationResult,
-                                const std::string& imagePath);
+                                const std::string& imagePath = std::string());
 
   /**
    * @brief Naive implementation of the localizer using the rig. Each image from

--- a/src/openMVG/localization/CCTagLocalizer.hpp
+++ b/src/openMVG/localization/CCTagLocalizer.hpp
@@ -124,8 +124,8 @@ public:
    * markers from the query image.
    * @param[in] imageSize The size of the query image.
    * @param[in] param The parameters to use.
-   * @param[out] occurences A map with a pair of indices for each association as 
-   * key and its occurrence as value.
+   * @param[out] occurences A map containing for each pair <pt3D_id, pt2D_id> 
+   * the number of times that the association has been seen
    * @param[out] pt2D The set of 2D points of the associations as they are given in \p queryRegions.
    * @param[out] pt3D The set of 3D points of the associations.
    * @param[in] The optional path to the query image file, used for debugging.

--- a/src/openMVG/localization/CCTagLocalizer.hpp
+++ b/src/openMVG/localization/CCTagLocalizer.hpp
@@ -9,6 +9,7 @@
 #include <openMVG/features/cctag/CCTAG_describer.hpp>
 #include <openMVG/sfm/sfm_data.hpp>
 #include <openMVG/sfm/pipelines/localization/SfM_Localizer.hpp>
+#include <openMVG/voctree/database.hpp>
 
 #include <iostream>
 #include <bitset>
@@ -135,6 +136,7 @@ public:
                           std::map< std::pair<IndexT, IndexT>, std::size_t > &occurences,
                           Mat &pt2D,
                           Mat &pt3D,
+                          std::vector<voctree::DocMatch>& matchedImages,
                           const std::string& imagePath = std::string()) const;
   
   virtual ~CCTagLocalizer();

--- a/src/openMVG/localization/CCTagLocalizer.hpp
+++ b/src/openMVG/localization/CCTagLocalizer.hpp
@@ -65,14 +65,6 @@ public:
                 cameras::Pinhole_Intrinsic_Radial_K3 &queryIntrinsics,
                 LocalizationResult & localizationResult,
                 const std::string& imagePath = std::string());
-  
-  bool localizeAllAssociations(const std::unique_ptr<features::Regions> &genQueryRegions,
-                                const std::pair<std::size_t, std::size_t> &imageSize,
-                                const LocalizerParameters *parameters,
-                                bool useInputIntrinsics,
-                                cameras::Pinhole_Intrinsic_Radial_K3 &queryIntrinsics,
-                                LocalizationResult & localizationResult,
-                                const std::string& imagePath = std::string());
 
   /**
    * @brief Naive implementation of the localizer using the rig. Each image from

--- a/src/openMVG/localization/CCTagLocalizer.hpp
+++ b/src/openMVG/localization/CCTagLocalizer.hpp
@@ -119,18 +119,22 @@ public:
    * points of the associations, in the same order as in \p occurences.
    * 
    * @param[in] queryRegions The input query regions containing the extracted 
-   * markers from the query image
-   * @param[in] param The parameters to use
+   * markers from the query image.
+   * @param[in] imageSize The size of the query image.
+   * @param[in] param The parameters to use.
    * @param[out] occurences A map with a pair of indices for each association as 
-   * key and its occurrence as value
-   * @param[out] pt2D The set of 2D points of the associations as they are given in \p queryRegions
-   * @param[out] pt3D The set of 3D points of the associations
+   * key and its occurrence as value.
+   * @param[out] pt2D The set of 2D points of the associations as they are given in \p queryRegions.
+   * @param[out] pt3D The set of 3D points of the associations.
+   * @param[in] The optional path to the query image file, used for debugging.
    */
   void getAllAssociations(const features::CCTAG_Regions &queryRegions,
+                          const std::pair<std::size_t, std::size_t> &imageSize,
                           const CCTagLocalizer::Parameters &param,
                           std::map< std::pair<IndexT, IndexT>, std::size_t > &occurences,
                           Mat &pt2D,
-                          Mat &pt3D) const;
+                          Mat &pt3D,
+                          const std::string& imagePath = std::string()) const;
   
   virtual ~CCTagLocalizer();
 

--- a/src/openMVG/localization/CCTagLocalizer.hpp
+++ b/src/openMVG/localization/CCTagLocalizer.hpp
@@ -65,6 +65,15 @@ public:
                 cameras::Pinhole_Intrinsic_Radial_K3 &queryIntrinsics,
                 LocalizationResult & localizationResult,
                 const std::string& imagePath = std::string());
+  
+  bool localizeAllAssociations(const std::unique_ptr<features::Regions> &genQueryRegions,
+                                const std::pair<std::size_t, std::size_t> &imageSize,
+                                const LocalizerParameters *parameters,
+                                bool useInputIntrinsics,
+                                cameras::Pinhole_Intrinsic_Radial_K3 &queryIntrinsics,
+                                LocalizationResult & localizationResult,
+                                const std::string& imagePath);
+
   /**
    * @brief Naive implementation of the localizer using the rig. Each image from
    * the rig is localized and then a bundle adjustment is run for optimizing the 

--- a/src/openMVG/localization/CMakeLists.txt
+++ b/src/openMVG/localization/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 ADD_LIBRARY(openMVG_localization
   ${localization_files_headers}
   ${localization_files_sources})
-TARGET_LINK_LIBRARIES(openMVG_localization openMVG_sfm openMVG_voctree openMVG_numeric ${Boost_LIBRARIES})
+TARGET_LINK_LIBRARIES(openMVG_localization openMVG_sfm openMVG_voctree openMVG_numeric openMVG_system ${Boost_LIBRARIES})
 IF(OpenMVG_USE_CCTAG)
   TARGET_LINK_LIBRARIES(openMVG_localization ${CCTAG_LIBRARIES})
 ENDIF(OpenMVG_USE_CCTAG)

--- a/src/openMVG/localization/VoctreeLocalizer.cpp
+++ b/src/openMVG/localization/VoctreeLocalizer.cpp
@@ -625,6 +625,8 @@ bool VoctreeLocalizer::localizeAllResults(const features::SIFT_Regions &queryReg
 {
   
   sfm::Image_Localizer_Match_Data resectionData;
+  // a map containing for each pair <pt3D_id, pt2D_id> the number of times that 
+  // the association has been seen
   std::map< std::pair<IndexT, IndexT>, std::size_t > occurences;
   
   // get all the association from the database images
@@ -833,7 +835,7 @@ void VoctreeLocalizer::getAllAssociations(const features::SIFT_Regions &queryReg
     }
     else
     {
-      POPART_COUT("[matching]\tFound " << vec_featureMatches.size() << " matches");
+      POPART_COUT("[matching]\tFound " << vec_featureMatches.size() << " geometrically validated matches");
     }
     assert(vec_featureMatches.size()>0);
     

--- a/src/openMVG/localization/VoctreeLocalizer.cpp
+++ b/src/openMVG/localization/VoctreeLocalizer.cpp
@@ -669,10 +669,10 @@ bool VoctreeLocalizer::localizeAllResults(const features::SIFT_Regions &queryReg
     if(!param._visualDebug.empty() && !imagePath.empty())
     {
       namespace bfs = boost::filesystem;
-      features::saveFeatures2SVG(imagePath, 
-                       queryImageSize, 
-                         resectionData.pt2D,
-                         param._visualDebug + "/" + bfs::path(imagePath).stem().string() + ".associations.svg");
+      features::saveFeatures2SVG(imagePath,
+                                 queryImageSize,
+                                 resectionData.pt2D,
+                                 param._visualDebug + "/" + bfs::path(imagePath).stem().string() + ".associations.svg");
     }
     localizationResult = LocalizationResult();
     return localizationResult.isValid();

--- a/src/openMVG/localization/VoctreeLocalizer.cpp
+++ b/src/openMVG/localization/VoctreeLocalizer.cpp
@@ -1413,19 +1413,17 @@ bool VoctreeLocalizer::localizeRig_naive(const std::vector<std::unique_ptr<featu
     //set the pose
     rigPose = vec_localizationResults[0].getPose();
   }
-  // if only one camera has been localized
-  else if(numLocalizedCam == 1)
-  {
-    // all the other cameras have not been localized just return the result of the 
-    // localized one
-    
-    // find the index of the localized camera
+  else
+  { 
+    // find the index of the first localized camera
     const std::size_t idx = std::distance(isLocalized.begin(), 
                                           std::find(isLocalized.begin(), isLocalized.end(), true));
     
     // useless safeguard as there should be at least 1 element at this point but
     // better safe than sorry
     assert(idx < isLocalized.size());
+    
+    POPART_COUT("Index of the first localized camera: " << idx);
     
     // if the only localized camera is the main camera
     if(idx==0)

--- a/src/openMVG/localization/rigResection.cpp
+++ b/src/openMVG/localization/rigResection.cpp
@@ -94,7 +94,7 @@ bool rigResection(const std::vector<Mat> &pts2d,
       
       // we first remove the distortion and then we transform the undistorted point in
       // normalized camera coordinates (inv(K)*undistortedPoint)
-      auto pt = currCamera.ima2cam(currCamera.remove_disto(pts2d[cam].col(i)));
+      auto pt = currCamera.ima2cam(currCamera.get_ud_pixel(pts2d[cam].col(i)));
       
       opengv::bearingVector_t bearing(pt(0), pt(1), 1.0);
       

--- a/src/openMVG/system/timer.cpp
+++ b/src/openMVG/system/timer.cpp
@@ -60,24 +60,23 @@ namespace system {
 
   double Timer::elapsed() const
   {
-    double elapsed_;
 #ifdef HAVE_CXX11_CHRONO
-    const auto end_ = std::chrono::high_resolution_clock::now();
-    elapsed_ = std::chrono::duration_cast<std::chrono::milliseconds>(end_ - start_).count() / 1000.;
+  return elapsedMs() / 1000.;
 #else
 
+  double elapsed_;
 #ifdef _WIN32
-    LARGE_INTEGER end_;
-    QueryPerformanceCounter(&end_);
-    elapsed_ = (static_cast<double>(end_.QuadPart) - start_) / frequency_;
+  LARGE_INTEGER end_;
+  QueryPerformanceCounter(&end_);
+  elapsed_ = (static_cast<double>(end_.QuadPart) - start_) / frequency_;
 #else
-    timeval end;
-    gettimeofday(&end, nullptr);
-    const double end_ = end.tv_sec + end.tv_usec * 1e-6;
-    elapsed_ = end_ - start_;
+  timeval end;
+  gettimeofday(&end, nullptr);
+  const double end_ = end.tv_sec + end.tv_usec * 1e-6;
+  elapsed_ = end_ - start_;
 #endif
+  return elapsed_;
 #endif // HAVE_CXX11_CHRONO
-    return elapsed_;
   }
 
   double Timer::elapsedMs() const

--- a/src/openMVG/system/timer.cpp
+++ b/src/openMVG/system/timer.cpp
@@ -12,6 +12,8 @@
 // ========================================================================== //
 
 #include <openMVG/system/timer.hpp>
+#include <cmath>
+
 #ifdef _WIN32
 # include <windows.h>
 #else
@@ -93,11 +95,48 @@ std::ostream& operator << (std::ostream& str, const Timer& t)
   return str << t.elapsed() << " s elapsed";
 }
 
+std::string prettyTime(double durationMs)
+{
+  std::string out;
 
-  std::ostream& operator << (std::ostream& str, const Timer& t)
+  const auto msecs = fmod(durationMs, 1000);
+  durationMs /= 1000.;
+  const std::size_t secs = std::size_t(fmod(durationMs, 60));
+  durationMs /= 60.;
+  const std::size_t mins = std::size_t(fmod(durationMs, 60));
+  durationMs /= 60.;
+  const std::size_t hours = std::size_t(fmod(durationMs, 24));
+  durationMs /= 24.;
+  const std::size_t days = durationMs;
+
+  bool printed_earlier = false;
+  if(days >= 1)
   {
-    return str << t.elapsed() << " s elapsed";
+    printed_earlier = true;
+    out += (std::to_string(days) + "d ");
   }
+  if(printed_earlier || hours >= 1)
+  {
+    printed_earlier = true;
+    out += (std::to_string(hours) + "h ");
+  }
+  if(printed_earlier || mins >= 1)
+  {
+    printed_earlier = true;
+    out += (std::to_string(mins) + "m ");
+  }
+  if(printed_earlier || secs >= 1)
+  {
+    printed_earlier = true;
+    out += (std::to_string(secs) + "s ");
+  }
+  if(printed_earlier || msecs >= 1)
+  {
+    printed_earlier = true;
+    out += (std::to_string(msecs) + "ms");
+  }
+  return out;
+}
 
 } // namespace system
 } // namespace openMVG

--- a/src/openMVG/system/timer.cpp
+++ b/src/openMVG/system/timer.cpp
@@ -21,45 +21,44 @@
 namespace openMVG {
 namespace system {
 
-  Timer::Timer()
-   {
-#ifdef HAVE_CXX11_CHRONO
-#else
+Timer::Timer()
+{
+#ifndef HAVE_CXX11_CHRONO
 #ifdef _WIN32
-    LARGE_INTEGER freq;
-    if (!QueryPerformanceFrequency(&freq))
-    {
-      const char *msg = "Failed to initialize high resolution timer!";
-      std::cerr << msg << std::endl;
-      throw std::runtime_error(msg);
-    }
-    frequency_ = static_cast<double>(freq.QuadPart);
-#endif
-#endif
-    reset();
-  }
-
-  void Timer::reset()
+  LARGE_INTEGER freq;
+  if (!QueryPerformanceFrequency(&freq))
   {
+    const char *msg = "Failed to initialize high resolution timer!";
+    std::cerr << msg << std::endl;
+    throw std::runtime_error(msg);
+  }
+  frequency_ = static_cast<double>(freq.QuadPart);
+#endif
+#endif
+  reset();
+}
+
+void Timer::reset()
+{
 #ifdef HAVE_CXX11_CHRONO
-    start_ = std::chrono::high_resolution_clock::now();
+  start_ = std::chrono::high_resolution_clock::now();
 #else
 
 #ifdef _WIN32
-    LARGE_INTEGER li_start_;
-    QueryPerformanceCounter(&li_start_);
-    start_ = static_cast<double>(li_start_.QuadPart);
+  LARGE_INTEGER li_start_;
+  QueryPerformanceCounter(&li_start_);
+  start_ = static_cast<double>(li_start_.QuadPart);
 #else
-    timeval start;
-    gettimeofday(&start, nullptr);
-    start_ = start.tv_sec + start.tv_usec * 1e-6;
+  timeval start;
+  gettimeofday(&start, nullptr);
+  start_ = start.tv_sec + start.tv_usec * 1e-6;
 #endif
 
 #endif // HAVE_CXX11_CHRONO
-  }
+}
 
-  double Timer::elapsed() const
-  {
+double Timer::elapsed() const
+{
 #ifdef HAVE_CXX11_CHRONO
   return elapsedMs() / 1000.;
 #else
@@ -77,17 +76,23 @@ namespace system {
 #endif
   return elapsed_;
 #endif // HAVE_CXX11_CHRONO
-  }
+}
 
-  double Timer::elapsedMs() const
-  {
+double Timer::elapsedMs() const
+{
 #ifdef HAVE_CXX11_CHRONO
-    const auto end_ = std::chrono::high_resolution_clock::now();
-    return std::chrono::duration_cast<std::chrono::milliseconds>(end_ - start_).count();
+  const auto end_ = std::chrono::high_resolution_clock::now();
+  return std::chrono::duration_cast<std::chrono::milliseconds>(end_ - start_).count();
 #else
-    return elapsed() * 1000.;
+  return elapsed() * 1000.;
 #endif // HAVE_CXX11_CHRONO
-  }
+}
+
+std::ostream& operator << (std::ostream& str, const Timer& t)
+{
+  return str << t.elapsed() << " s elapsed";
+}
+
 
   std::ostream& operator << (std::ostream& str, const Timer& t)
   {

--- a/src/openMVG/system/timer.hpp
+++ b/src/openMVG/system/timer.hpp
@@ -56,7 +56,6 @@ namespace system {
  * 
  * @param durationMs the duration in milliseconds.
  * @return a formatted string
- * @note adapted form http://ideone.com/bBNHQp
  */  
 std::string prettyTime(double durationMs);
 

--- a/src/openMVG/system/timer.hpp
+++ b/src/openMVG/system/timer.hpp
@@ -18,6 +18,7 @@
 #include <chrono>
 #endif
 #include <iostream>
+#include <string>
 
 namespace openMVG {
 namespace system {
@@ -48,6 +49,16 @@ namespace system {
   
   // print the elapsed time
   std::ostream& operator << (std::ostream&, const Timer&);
+  
+/**
+ * @brief Prints the duration in the format #d #h #m #s #ms starting from the non-zero
+ * most significant entity (ie it does not print #d if d is 0 and so on...).
+ * 
+ * @param durationMs the duration in milliseconds.
+ * @return a formatted string
+ * @note adapted form http://ideone.com/bBNHQp
+ */  
+std::string prettyTime(double durationMs);
 
 } // namespace system
 } // namespace openMVG

--- a/src/software/RigCalibration/CMakeLists.txt
+++ b/src/software/RigCalibration/CMakeLists.txt
@@ -14,6 +14,7 @@ if(OpenMVG_USE_BOOST)
     openMVG_dataio
     openMVG_image
     openMVG_calibration
+    openMVG_system
     ${OpenCV_LIBRARIES}
     ${Boost_LIBRARIES}
     )

--- a/src/software/RigCalibration/main_cameraCalibration.cpp
+++ b/src/software/RigCalibration/main_cameraCalibration.cpp
@@ -246,7 +246,7 @@ int main(int argc, char** argv)
                         totalAvgErr, maxTotalAvgErr, minInputFrames, calibInputFrames,
                         calibImageScore, rejectInputFrames);
 
-  std::cout << "Calibration duration: " << duration.elapsedMs() << "ms" << std::endl;
+  std::cout << "Calibration duration: " << openMVG::system::prettyTime(duration.elapsedMs()) << std::endl;
 
   openMVG::calibration::saveCameraParams(outputFilename, imageSize,
                                          boardSize, squareSize, aspectRatio,
@@ -261,7 +261,7 @@ int main(int argc, char** argv)
                                     feed, calibInputFrames, rejectInputFrames, remainingImagesIndexes,
                                     cameraMatrix, distCoeffs, imageSize);
 
-  std::cout << "Total duration: " << openMVG::system::prettyTime(durationAlgo.elapsed()) << "s" << std::endl;
+  std::cout << "Total duration: " << openMVG::system::prettyTime(durationAlgo.elapsedMs()) << std::endl;
 
   return EXIT_SUCCESS;
 }

--- a/src/software/RigCalibration/main_cameraCalibration.cpp
+++ b/src/software/RigCalibration/main_cameraCalibration.cpp
@@ -65,9 +65,9 @@ int main(int argc, char** argv)
           ("output,o", po::value<std::string>(&outputFilename)->required(),
            "Output filename for intrinsic [and extrinsic] parameters.\n")
           ("pattern,p", po::value<openMVG::calibration::Pattern>(&pattern)->default_value(pattern),
-           "Type of pattern: 'chessboard', 'circles', 'asymmetric_circles'"
+           "Type of pattern: 'CHESSBOARD', 'CIRCLES', 'ASYMMETRIC_CIRCLES'"
             #ifdef HAVE_CCTAG
-//                      " or 'cctag'"
+//                      " or 'CCTAG'"
             #endif
           ".\n")
           ("size,s", po::value<std::vector < std::size_t >> (&checkerboardSize)->multitoken(),

--- a/src/software/RigCalibration/main_cameraCalibration.cpp
+++ b/src/software/RigCalibration/main_cameraCalibration.cpp
@@ -213,7 +213,7 @@ int main(int argc, char** argv)
   }
 
   
-  std::cout << "find points duration: " << duration.elapsed() << "s" << std::endl;
+  std::cout << "find points duration: " << openMVG::system::prettyTime(duration.elapsedMs()) << std::endl;
   std::cout << "Grid detected in " << imagePoints.size() << " images on " << iInputFrame << " input images." << std::endl;
 
   if (imagePoints.empty())


### PR DESCRIPTION
Some improvements for the cctag localizer
* updated the cctag describer according to the latest API 
* better debugging organization, the matchings for each query image are saved in a separate folder
* missing set preset for cctag
* implemented a new method for localization that collects first all the association and the it estimates the pose

Spur of the moments bugfixes
* fixed a major bug for naive method in both cctag and voctree 77f09e2
* fixed another major bug for opengv method concerning undistortion (connected to poparteu/openMVG#225)
