### PR TITLE
Pimpl'ed alembic

### DIFF
--- a/src/openMVG/sfm/AlembicExporter.cpp
+++ b/src/openMVG/sfm/AlembicExporter.cpp
@@ -64,10 +64,7 @@ struct AlembicExporter::DataImpl
 
 AlembicExporter::AlembicExporter(const std::string &filename)
 : _data(new DataImpl(filename))
-, counter(0)
-{
-
-}
+{ }
 
 AlembicExporter::~AlembicExporter()
 {

--- a/src/openMVG/sfm/AlembicExporter.cpp
+++ b/src/openMVG/sfm/AlembicExporter.cpp
@@ -8,6 +8,10 @@
 #if HAVE_ALEMBIC
 
 #include "AlembicExporter.hpp"
+
+#include <Alembic/AbcGeom/All.h>
+#include <Alembic/AbcCoreHDF5/All.h>
+
 #include "openMVG/sfm/sfm_view_metadata.hpp"
 #include "openMVG/version.hpp"
 
@@ -19,25 +23,49 @@ using namespace Alembic::Abc;
 namespace AbcG = Alembic::AbcGeom;
 using namespace AbcG;
 
+struct AlembicExporter::DataImpl
+{
+  DataImpl(const std::string &filename)
+  : _archive(Alembic::AbcCoreHDF5::WriteArchive(), filename)
+  , _topObj(_archive, Alembic::Abc::kTop)
+  {
+    // Create MVG hierarchy
+    _mvgRoot = Alembic::Abc::OObject(_topObj, "mvgRoot");
+    _mvgCameras = Alembic::Abc::OObject(_mvgRoot, "mvgCameras");
+    _mvgCloud = Alembic::Abc::OObject(_mvgRoot, "mvgCloud");
+    _mvgPointCloud = Alembic::Abc::OObject(_mvgCloud, "mvgPointCloud");
+
+    // Add version as custom property
+    auto userProps = _mvgRoot.getProperties();
+    OUInt32ArrayProperty propAbcVersion(userProps, "mvg_ABC_version");
+    OUInt32ArrayProperty propOpenMVGVersion(userProps, "mvg_openMVG_version");
+    const std::vector<uint32_t> abcVersion = {1, 0};
+    propAbcVersion.set(abcVersion);
+    const std::vector<uint32_t> openMVGVersion = {OPENMVG_VERSION_MAJOR, OPENMVG_VERSION_MINOR, OPENMVG_VERSION_REVISION};
+    propOpenMVGVersion.set(openMVGVersion);
+  }
+  
+  Alembic::Abc::OArchive _archive;
+  Alembic::Abc::OObject _topObj;
+  Alembic::Abc::OObject _mvgRoot;
+  Alembic::Abc::OObject _mvgCameras;
+  Alembic::Abc::OObject _mvgCloud;
+  Alembic::Abc::OObject _mvgPointCloud;
+  Alembic::AbcGeom::OXform _mxform;
+  Alembic::AbcGeom::OCamera _mcamObj;
+  Alembic::AbcGeom::OUInt32ArrayProperty _mpropSensorSize_pix;
+  Alembic::AbcGeom::OStringProperty _mimagePlane;
+  Alembic::AbcGeom::OUInt32Property _mpropViewId;
+  Alembic::AbcGeom::OUInt32Property _mpropIntrinsicId;
+  Alembic::AbcGeom::OStringProperty _mmvg_intrinsicType;
+  Alembic::AbcGeom::ODoubleArrayProperty _mmvg_intrinsicParams;
+};
+
+
 AlembicExporter::AlembicExporter(const std::string &filename)
-: archive(Alembic::AbcCoreHDF5::WriteArchive(), filename)
-, topObj(archive, Alembic::Abc::kTop)
+: _data(new DataImpl(filename))
 , counter(0)
 {
-  // Create MVG hierarchy
-  mvgRoot = Alembic::Abc::OObject(topObj, "mvgRoot");
-  mvgCameras = Alembic::Abc::OObject(mvgRoot, "mvgCameras");
-  mvgCloud = Alembic::Abc::OObject(mvgRoot, "mvgCloud");
-  mvgPointCloud = Alembic::Abc::OObject(mvgCloud, "mvgPointCloud"); 
-
-  // Add version as custom property
-  auto userProps = mvgRoot.getProperties();
-  OUInt32ArrayProperty propAbcVersion(userProps, "mvg_ABC_version");
-  OUInt32ArrayProperty propOpenMVGVersion(userProps, "mvg_openMVG_version");
-  const std::vector<uint32_t> abcVersion = {1, 0};
-  propAbcVersion.set(abcVersion);
-  const std::vector<uint32_t> openMVGVersion = {OPENMVG_VERSION_MAJOR, OPENMVG_VERSION_MINOR, OPENMVG_VERSION_REVISION};
-  propOpenMVGVersion.set(openMVGVersion);
 
 }
 
@@ -67,7 +95,7 @@ void AlembicExporter::addPoints(const sfm::Landmarks &landmarks, bool withVisibi
   std::vector<Alembic::Util::uint64_t> ids(positions.size());
   iota(begin(ids), end(ids), 0);
 
-  OPoints partsOut(mvgPointCloud, "particleShape1");
+  OPoints partsOut(_data->_mvgPointCloud, "particleShape1");
   OPointsSchema &pSchema = partsOut.getSchema();
 
   OPointsSchema::Sample psamp(std::move(V3fArraySample(positions)), std::move(UInt64ArraySample(ids)));
@@ -169,7 +197,7 @@ void AlembicExporter::appendCamera(const std::string &cameraName,
   std::stringstream ss;
   ss << std::setfill('0') << std::setw(5) << id_pose;
   ss << "_" << cameraName << "_" << id_view;
-  Alembic::AbcGeom::OXform xform(mvgCameras, "camxform_" + ss.str());
+  Alembic::AbcGeom::OXform xform(_data->_mvgCameras, "camxform_" + ss.str());
   xform.getSchema().set(xformsample);
 
   // Camera intrinsic parameters
@@ -240,27 +268,27 @@ void AlembicExporter::initAnimatedCamera(const std::string& cameraName)
   // Create the camera transform object
   std::stringstream ss;
   ss << cameraName;
-  mxform = Alembic::AbcGeom::OXform(mvgCameras, "animxform_" + ss.str());
-  mxform.getSchema().setTimeSampling(tsp);
+  _data->_mxform = Alembic::AbcGeom::OXform(_data->_mvgCameras, "animxform_" + ss.str());
+  _data->_mxform.getSchema().setTimeSampling(tsp);
   
   // Create the camera parameters object (intrinsics & custom properties)
-  mcamObj = OCamera(mxform, "animcam_" + ss.str());
-  mcamObj.getSchema().setTimeSampling(tsp);
+  _data->_mcamObj = OCamera(_data->_mxform, "animcam_" + ss.str());
+  _data->_mcamObj.getSchema().setTimeSampling(tsp);
   
   // Add the custom properties
-  auto userProps = mcamObj.getSchema().getUserProperties();
+  auto userProps = _data->_mcamObj.getSchema().getUserProperties();
   // Sensor size
-  mpropSensorSize_pix = OUInt32ArrayProperty(userProps, "mvg_sensorSizePix", tsp);
+  _data->_mpropSensorSize_pix = OUInt32ArrayProperty(userProps, "mvg_sensorSizePix", tsp);
   // Image path
-  mimagePlane = OStringProperty(userProps, "mvg_imagePath", tsp);
+  _data->_mimagePlane = OStringProperty(userProps, "mvg_imagePath", tsp);
   // View id
-  mpropViewId = OUInt32Property(userProps, "mvg_viewId", tsp);
+  _data->_mpropViewId = OUInt32Property(userProps, "mvg_viewId", tsp);
   // Intrinsic id
-  mpropIntrinsicId = OUInt32Property(userProps, "mvg_intrinsicId", tsp);
+  _data->_mpropIntrinsicId = OUInt32Property(userProps, "mvg_intrinsicId", tsp);
   // Intrinsic type (ex: PINHOLE_CAMERA_RADIAL3)
-  mmvg_intrinsicType = OStringProperty(userProps, "mvg_intrinsicType", tsp);
+  _data->_mmvg_intrinsicType = OStringProperty(userProps, "mvg_intrinsicType", tsp);
   // Intrinsic parameters
-  mmvg_intrinsicParams = ODoubleArrayProperty(userProps, "mvg_intrinsicParams", tsp);
+  _data->_mmvg_intrinsicParams = ODoubleArrayProperty(userProps, "mvg_intrinsicParams", tsp);
 }
 
 void AlembicExporter::addCameraKeyframe(const geometry::Pose3 &pose,
@@ -302,7 +330,7 @@ void AlembicExporter::addCameraKeyframe(const geometry::Pose3 &pose,
   xformsample.setMatrix(xformMatrix);
   
   // Attach it to the schema of the OXform
-  mxform.getSchema().set(xformsample);
+  _data->_mxform.getSchema().set(xformsample);
   
   // Camera intrinsic parameters
   CameraSample camSample;
@@ -332,37 +360,37 @@ void AlembicExporter::addCameraKeyframe(const geometry::Pose3 &pose,
   
   // Add sensor width (largest image side) in pixels as custom property
   std::vector<uint32_t> sensorSize_pix = {uint32_t(sensorWidth_pix), uint32_t(sensorHeight_pix)};
-  mpropSensorSize_pix.set(sensorSize_pix);
+  _data->_mpropSensorSize_pix.set(sensorSize_pix);
   
   // Set custom attributes
   // Image path
-  mimagePlane.set(imagePath);
+  _data->_mimagePlane.set(imagePath);
 
   // View id
-  mpropViewId.set(id_view);
+  _data->_mpropViewId.set(id_view);
   // Intrinsic id
-  mpropIntrinsicId.set(id_intrinsic);
+  _data->_mpropIntrinsicId.set(id_intrinsic);
   // Intrinsic type
-  mmvg_intrinsicType.set(cam->getTypeStr());
+  _data->_mmvg_intrinsicType.set(cam->getTypeStr());
   // Intrinsic parameters
   std::vector<double> intrinsicParams = cam->getParams();
-  mmvg_intrinsicParams.set(intrinsicParams);
+  _data->_mmvg_intrinsicParams.set(intrinsicParams);
   
   // Attach intrinsic parameters to camera object
-  mcamObj.getSchema().set(camSample);
+  _data->_mcamObj.getSchema().set(camSample);
 }
 
 void AlembicExporter::jumpKeyframe(const std::string &imagePath)
 {
-  if(mxform.getSchema().getNumSamples() == 0)
+  if(_data->_mxform.getSchema().getNumSamples() == 0)
   {
     cameras::Pinhole_Intrinsic default_intrinsic;
     this->addCameraKeyframe(geometry::Pose3(), &default_intrinsic, imagePath, 0, 0);
   }
   else
   {
-    mxform.getSchema().setFromPrevious();
-    mcamObj.getSchema().setFromPrevious();
+    _data->_mxform.getSchema().setFromPrevious();
+    _data->_mcamObj.getSchema().setFromPrevious();
   }
 }
 
@@ -416,6 +444,11 @@ void AlembicExporter::add(const sfm::SfM_Data &sfmdata, sfm::ESfM_Data flags_par
   }
 }
 
+
+std::string AlembicExporter::getFilename()
+{
+  return _data->_archive.getName();
+}
 
 } //namespace dataio
 } //namespace openMVG

--- a/src/openMVG/sfm/AlembicExporter.hpp
+++ b/src/openMVG/sfm/AlembicExporter.hpp
@@ -2,12 +2,11 @@
 
 #pragma once
 
-
-#include <Alembic/AbcGeom/All.h>
-#include <Alembic/AbcCoreHDF5/All.h>
-
 #include <openMVG/sfm/sfm_data.hpp>
 #include <openMVG/sfm/sfm_data_io.hpp>
+
+#include <memory>
+#include <string>
 
 namespace openMVG {
 namespace dataio {
@@ -83,24 +82,21 @@ public:
    */
   void add(const sfm::SfM_Data &sfmdata, sfm::ESfM_Data flags_part = sfm::ESfM_Data::ALL);
 
+  /**
+   * @brief Return the filename associated to the alembic file.
+   * @return the filename associated to the alembivc file.
+   */
+  std::string getFilename();
+
   virtual ~AlembicExporter();
 
 private:
-  Alembic::Abc::OArchive archive;
-  Alembic::Abc::OObject topObj;
-  Alembic::Abc::OObject mvgRoot;
-  Alembic::Abc::OObject mvgCameras;
-  Alembic::Abc::OObject mvgCloud;
-  Alembic::Abc::OObject mvgPointCloud;
+  
+  struct DataImpl;
+  std::unique_ptr<DataImpl> _data;
+
   unsigned int counter;
-  Alembic::AbcGeom::OXform mxform;
-  Alembic::AbcGeom::OCamera mcamObj;
-  Alembic::AbcGeom::OUInt32ArrayProperty mpropSensorSize_pix;
-  Alembic::AbcGeom::OStringProperty mimagePlane;
-  Alembic::AbcGeom::OUInt32Property mpropViewId;
-  Alembic::AbcGeom::OUInt32Property mpropIntrinsicId;
-  Alembic::AbcGeom::OStringProperty mmvg_intrinsicType;
-  Alembic::AbcGeom::ODoubleArrayProperty mmvg_intrinsicParams;
+
 };
 
 } // namespace data_io

--- a/src/openMVG/sfm/AlembicExporter.hpp
+++ b/src/openMVG/sfm/AlembicExporter.hpp
@@ -98,8 +98,6 @@ private:
   struct DataImpl;
   std::unique_ptr<DataImpl> _data;
 
-  unsigned int counter;
-
 };
 
 } // namespace data_io

--- a/src/openMVG/sfm/AlembicExporter.hpp
+++ b/src/openMVG/sfm/AlembicExporter.hpp
@@ -4,6 +4,9 @@
 
 #include <openMVG/sfm/sfm_data.hpp>
 #include <openMVG/sfm/sfm_data_io.hpp>
+#include <openMVG/geometry/pose3.hpp>
+#include <openMVG/cameras/Camera_Pinhole.hpp>
+#include <openMVG/types.hpp>
 
 #include <memory>
 #include <string>

--- a/src/openMVG/sfm/AlembicImporter.cpp
+++ b/src/openMVG/sfm/AlembicImporter.cpp
@@ -353,9 +353,9 @@ void visitObject(IObject iObj, M44d mat, sfm::SfM_Data &sfmdata, sfm::ESfM_Data 
   }
 }
 
-struct AlembicImporter::ObjImpl
+struct AlembicImporter::DataImpl
 {
-  ObjImpl(const IObject &obj)
+  DataImpl(const IObject &obj)
   {
     _rootEntity = obj;
   }
@@ -370,7 +370,7 @@ AlembicImporter::AlembicImporter(const std::string &filename)
   Abc::IArchive archive = factory.getArchive(filename, coreType);
 
   // TODO : test if archive is correctly opened
-  _objImpl.reset(new ObjImpl(archive.getTop()));
+  _objImpl.reset(new DataImpl(archive.getTop()));
 }
 
 AlembicImporter::~AlembicImporter()

--- a/src/openMVG/sfm/AlembicImporter.cpp
+++ b/src/openMVG/sfm/AlembicImporter.cpp
@@ -10,6 +10,7 @@
 
 #include <Alembic/AbcGeom/All.h>
 #include <Alembic/AbcCoreFactory/All.h>
+#include <Alembic/AbcCoreHDF5/All.h>
 
 
 using namespace Alembic::Abc;
@@ -352,6 +353,16 @@ void visitObject(IObject iObj, M44d mat, sfm::SfM_Data &sfmdata, sfm::ESfM_Data 
   }
 }
 
+struct AlembicImporter::ObjImpl
+{
+  ObjImpl(const IObject &obj)
+  {
+    _rootEntity = obj;
+  }
+  
+  IObject _rootEntity;
+};
+
 AlembicImporter::AlembicImporter(const std::string &filename)
 {
   Alembic::AbcCoreFactory::IFactory factory;
@@ -359,14 +370,18 @@ AlembicImporter::AlembicImporter(const std::string &filename)
   Abc::IArchive archive = factory.getArchive(filename, coreType);
 
   // TODO : test if archive is correctly opened
-  _rootEntity = archive.getTop();
+  _objImpl.reset(new ObjImpl(archive.getTop()));
+}
+
+AlembicImporter::~AlembicImporter()
+{
 }
 
 void AlembicImporter::populate(sfm::SfM_Data &sfmdata, sfm::ESfM_Data flags_part)
 {
   // TODO : handle the case where the archive wasn't correctly opened
   M44d xformMat;
-  visitObject(_rootEntity, xformMat, sfmdata, flags_part);
+  visitObject(_objImpl->_rootEntity, xformMat, sfmdata, flags_part);
 
   // TODO: fusion of common intrinsics
 }

--- a/src/openMVG/sfm/AlembicImporter.cpp
+++ b/src/openMVG/sfm/AlembicImporter.cpp
@@ -78,7 +78,7 @@ inline ICompoundProperty getAbcUserProperties(ABCSCHEMA& schema)
 }
 
 
-bool AlembicImporter::readPointCloud(IObject iObj, M44d mat, sfm::SfM_Data &sfmdata, sfm::ESfM_Data flags_part)
+bool readPointCloud(IObject iObj, M44d mat, sfm::SfM_Data &sfmdata, sfm::ESfM_Data flags_part)
 {
   using namespace openMVG::geometry;
   using namespace openMVG::sfm;
@@ -179,7 +179,7 @@ bool AlembicImporter::readPointCloud(IObject iObj, M44d mat, sfm::SfM_Data &sfmd
   return true;
 }
 
-bool AlembicImporter::readCamera(IObject iObj, M44d mat, sfm::SfM_Data &sfmdata, sfm::ESfM_Data flags_part, const index_t sampleFrame)
+bool readCamera(IObject iObj, M44d mat, sfm::SfM_Data &sfmdata, sfm::ESfM_Data flags_part, const index_t sampleFrame = 0)
 {
   using namespace openMVG::geometry;
   using namespace openMVG::cameras;
@@ -306,7 +306,7 @@ bool AlembicImporter::readCamera(IObject iObj, M44d mat, sfm::SfM_Data &sfmdata,
 
 
 // Top down read of 3d objects
-void AlembicImporter::visitObject(IObject iObj, M44d mat, sfm::SfM_Data &sfmdata, sfm::ESfM_Data flags_part)
+void visitObject(IObject iObj, M44d mat, sfm::SfM_Data &sfmdata, sfm::ESfM_Data flags_part)
 {
   // std::cout << "ABC visit: " << iObj.getFullName() << std::endl;
   

--- a/src/openMVG/sfm/AlembicImporter.hpp
+++ b/src/openMVG/sfm/AlembicImporter.hpp
@@ -26,8 +26,8 @@ public:
 
 private:
   
-  struct ObjImpl;
-  std::unique_ptr<ObjImpl> _objImpl;
+  struct DataImpl;
+  std::unique_ptr<DataImpl> _objImpl;
 };
 
 } // namespace mockup

--- a/src/openMVG/sfm/AlembicImporter.hpp
+++ b/src/openMVG/sfm/AlembicImporter.hpp
@@ -8,15 +8,8 @@
         
 #pragma once
 
-#include <Alembic/AbcGeom/All.h>
-#include <Alembic/AbcCoreHDF5/All.h>
-
 #include <openMVG/sfm/sfm_data.hpp>
 #include <openMVG/sfm/sfm_data_io.hpp>
-
-using namespace Alembic::Abc;
-namespace AbcG = Alembic::AbcGeom;
-using namespace AbcG;
 
 namespace openMVG {
 namespace dataio {
@@ -25,13 +18,14 @@ class AlembicImporter
 {
 public:
   explicit AlembicImporter(const std::string &filename);
-  ~AlembicImporter() = default;
+  ~AlembicImporter();
 
   void populate(sfm::SfM_Data &sfmdata, sfm::ESfM_Data flags_part = sfm::ESfM_Data::ALL);
 
 private:
-
-  IObject _rootEntity;
+  
+  struct ObjImpl;
+  std::unique_ptr<ObjImpl> _objImpl;
 };
 
 } // namespace mockup

--- a/src/openMVG/sfm/AlembicImporter.hpp
+++ b/src/openMVG/sfm/AlembicImporter.hpp
@@ -30,11 +30,7 @@ public:
   void populate(sfm::SfM_Data &sfmdata, sfm::ESfM_Data flags_part = sfm::ESfM_Data::ALL);
 
 private:
-  bool readPointCloud(IObject iObj, M44d mat, sfm::SfM_Data &sfmdata, sfm::ESfM_Data flags_part);
-  bool readCamera(IObject iObj, M44d mat, sfm::SfM_Data &sfmdata, sfm::ESfM_Data flags_part, const index_t sampleFrame = 0);
-  
-  //@todo complete the interface, also maybe parameters need to be passed by reference?
-  void visitObject(IObject iObj, M44d mat, sfm::SfM_Data &sfmdata, sfm::ESfM_Data flags_part = sfm::ESfM_Data::ALL);
+
   IObject _rootEntity;
 };
 

--- a/src/openMVG/sfm/AlembicImporter.hpp
+++ b/src/openMVG/sfm/AlembicImporter.hpp
@@ -11,6 +11,8 @@
 #include <openMVG/sfm/sfm_data.hpp>
 #include <openMVG/sfm/sfm_data_io.hpp>
 
+#include <string>
+
 namespace openMVG {
 namespace dataio {
 

--- a/src/software/Localization/main_rigLocalizer.cpp
+++ b/src/software/Localization/main_rigLocalizer.cpp
@@ -18,6 +18,7 @@
 #include <boost/accumulators/statistics/min.hpp>
 #include <boost/accumulators/statistics/max.hpp>
 #include <boost/accumulators/statistics/sum.hpp>
+#include <boost/ptr_container/ptr_vector.hpp>
 
 #include <iostream>
 #include <string>
@@ -386,14 +387,14 @@ int main(int argc, char** argv)
   exporter.initAnimatedCamera("rig");
   exporter.addPoints(localizer->getSfMData().GetLandmarks());
   
-  std::vector<std::unique_ptr<dataio::AlembicExporter> > cameraExporters;
+  boost::ptr_vector<dataio::AlembicExporter> cameraExporters;
   cameraExporters.reserve(numCameras);
   // this contains the full path and the root name of the file without the extension
   const std::string basename = (bfs::path(exportFile).parent_path() / bfs::path(exportFile).stem()).string();
   for(std::size_t i = 0; i < numCameras; ++i)
   {
-    cameraExporters.emplace_back( std::unique_ptr<dataio::AlembicExporter>( new dataio::AlembicExporter(basename+".cam"+myToString(i, 2)+".abc")));
-    cameraExporters.back()->initAnimatedCamera("cam"+myToString(i, 2));
+    cameraExporters.push_back( new dataio::AlembicExporter(basename+".cam"+myToString(i, 2)+".abc"));
+    cameraExporters.back().initAnimatedCamera("cam"+myToString(i, 2));
   }
 #endif
 
@@ -515,7 +516,7 @@ int main(int argc, char** argv)
         POPART_COUT("cam pose" << camIDX << "\n" <<  localizationResults[camIDX].getPose().rotation() << "\n" << localizationResults[camIDX].getPose().center());
         if(camIDX > 0)
           POPART_COUT("cam subpose" << camIDX-1 << "\n" <<  vec_subPoses[camIDX-1].rotation() << "\n" << vec_subPoses[camIDX-1].center());
-        cameraExporters[camIDX]->addCameraKeyframe(localizationResults[camIDX].getPose(), &vec_queryIntrinsics[camIDX], mediaPath, frameCounter, frameCounter);
+        cameraExporters[camIDX].addCameraKeyframe(localizationResults[camIDX].getPose(), &vec_queryIntrinsics[camIDX], mediaPath, frameCounter, frameCounter);
       }
 #endif
     }
@@ -527,7 +528,7 @@ int main(int argc, char** argv)
       assert(cameraExporters.size()==numCameras);
       for(std::size_t camIDX = 0; camIDX < numCameras; ++camIDX)
       {
-        cameraExporters[camIDX]->jumpKeyframe();
+        cameraExporters[camIDX].jumpKeyframe();
       }
 #endif
     }

--- a/src/software/Localization/main_rigLocalizer.cpp
+++ b/src/software/Localization/main_rigLocalizer.cpp
@@ -386,14 +386,14 @@ int main(int argc, char** argv)
   exporter.initAnimatedCamera("rig");
   exporter.addPoints(localizer->getSfMData().GetLandmarks());
   
-  std::vector<dataio::AlembicExporter> cameraExporters;
+  std::vector<std::unique_ptr<dataio::AlembicExporter> > cameraExporters;
   cameraExporters.reserve(numCameras);
   // this contains the full path and the root name of the file without the extension
   const std::string basename = (bfs::path(exportFile).parent_path() / bfs::path(exportFile).stem()).string();
   for(std::size_t i = 0; i < numCameras; ++i)
   {
-    cameraExporters.emplace_back(basename+".cam"+myToString(i, 2)+".abc");
-    cameraExporters.back().initAnimatedCamera("cam"+myToString(i, 2));
+    cameraExporters.emplace_back( std::unique_ptr<dataio::AlembicExporter>( new dataio::AlembicExporter(basename+".cam"+myToString(i, 2)+".abc")));
+    cameraExporters.back()->initAnimatedCamera("cam"+myToString(i, 2));
   }
 #endif
 
@@ -515,7 +515,7 @@ int main(int argc, char** argv)
         POPART_COUT("cam pose" << camIDX << "\n" <<  localizationResults[camIDX].getPose().rotation() << "\n" << localizationResults[camIDX].getPose().center());
         if(camIDX > 0)
           POPART_COUT("cam subpose" << camIDX-1 << "\n" <<  vec_subPoses[camIDX-1].rotation() << "\n" << vec_subPoses[camIDX-1].center());
-        cameraExporters[camIDX].addCameraKeyframe(localizationResults[camIDX].getPose(), &vec_queryIntrinsics[camIDX], mediaPath, frameCounter, frameCounter);
+        cameraExporters[camIDX]->addCameraKeyframe(localizationResults[camIDX].getPose(), &vec_queryIntrinsics[camIDX], mediaPath, frameCounter, frameCounter);
       }
 #endif
     }
@@ -527,7 +527,7 @@ int main(int argc, char** argv)
       assert(cameraExporters.size()==numCameras);
       for(std::size_t camIDX = 0; camIDX < numCameras; ++camIDX)
       {
-        cameraExporters[camIDX].jumpKeyframe();
+        cameraExporters[camIDX]->jumpKeyframe();
       }
 #endif
     }


### PR DESCRIPTION
Hidden implementation of Alembic{Im,Ex}porter avoids having to include alembic headers in openMVG headers.

Now, in theory, we don't need to find Alembic when using openMVG as external library

connected to poparteu/openMVG#221