### PR TITLE
Clang 3.9 fix

### DIFF
--- a/src/openMVG/matching_image_collection/Cascade_Hashing_Matcher_Regions_AllInMemory.cpp
+++ b/src/openMVG/matching_image_collection/Cascade_Hashing_Matcher_Regions_AllInMemory.cpp
@@ -109,7 +109,7 @@ void Match
     const size_t dimension = regionsI.DescriptorLength();
 
     Eigen::Map<BaseMat> mat_I( (ScalarT*)tabI, regionsI.RegionCount(), dimension);
-    const HashedDescriptions hashed_description = cascade_hasher.CreateHashedDescriptions(mat_I,
+    HashedDescriptions hashed_description = cascade_hasher.CreateHashedDescriptions(mat_I,
       zero_mean_descriptor);
 #ifdef OPENMVG_USE_OPENMP
     #pragma omp critical
@@ -144,7 +144,7 @@ void Match
 #endif
     for (int j = 0; j < (int)indexToCompare.size(); ++j)
     {
-      const size_t J = indexToCompare[j];
+      size_t J = indexToCompare[j];
       const features::Regions &regionsJ = *regions_provider.regions_per_view.at(J).get();
 
       if (regions_provider.regions_per_view.count(J) == 0

--- a/src/openMVG/matching_image_collection/GeometricFilter.hpp
+++ b/src/openMVG/matching_image_collection/GeometricFilter.hpp
@@ -70,7 +70,7 @@ void ImageCollectionGeometricFilter::Robust_model_estimation
     PairWiseMatches::const_iterator iter = putative_matches.begin();
     advance(iter,i);
 
-    const Pair current_pair = iter->first;
+    Pair current_pair = iter->first;
     const std::vector<IndMatch> & vec_PutativeMatches = iter->second;
 
     //-- Apply the geometric filter (robust model estimation)

--- a/src/openMVG/types.hpp
+++ b/src/openMVG/types.hpp
@@ -36,7 +36,7 @@ struct Hash_Map : std::unordered_map<Key, Value> {};
 #else
 template<typename K, typename V>
 struct Hash_Map : std::map<K, V, std::less<K>,
- Eigen::aligned_allocator<std::pair<K,V> > > {};
+ Eigen::aligned_allocator<std::pair<const K,V> > > {};
 #endif
 
 } // namespace openMVG


### PR DESCRIPTION
Clang 3.9 is more strict with const/no-const qualifiers.